### PR TITLE
fix: :bug: put shaded windows to float state to avoid layout breakage

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -134,6 +134,12 @@ export interface Controller {
   onWindowFocused(window: Window): void;
 
   /**
+   * React to the window shade state change
+   * @param window the window whose state was changed
+   */
+  onWindowShadeChanged(window: Window): void;
+
+  /**
    * Ask engine to manage the window
    * @param win the window which needs to be managed.
    */
@@ -360,6 +366,21 @@ export class TilingController implements Controller {
 
       this.engine.minimizeOthers(window);
     }
+  }
+
+  public onWindowShadeChanged(win: Window): void {
+    this.log.log(`onWindowShadeChanged, window: ${win}`);
+
+    // NOTE: Float shaded windows and change their state back once unshaded
+    // For some reason shaded windows break our tiling geometry,
+    // once resized. To avoid that, we put them to floating state.
+    if (win.shaded) {
+      win.state = WindowState.Floating;
+    } else {
+      win.state = win.statePreviouslyAskedToChangeTo;
+    }
+
+    this.engine.arrange();
   }
 
   public manageWindow(win: Window): void {

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -408,6 +408,10 @@ export class KWinDriver implements DriverContext {
     this.connect(client.desktopChanged, () =>
       this.controller.onWindowChanged(window, `desktop=${client.desktop}`)
     );
+
+    this.connect(client.shadeChanged, () => {
+      this.controller.onWindowShadeChanged(window);
+    });
   }
 
   // TODO: private onConfigChanged = () => {

--- a/src/driver/window.ts
+++ b/src/driver/window.ts
@@ -22,6 +22,7 @@ export interface DriverWindow {
   readonly active: boolean;
   surface: DriverSurface;
   minimized: boolean;
+  shaded: boolean;
 
   commit(geometry?: Rect, noBorder?: boolean, keepAbove?: boolean): void;
   visible(srf: DriverSurface): boolean;
@@ -85,6 +86,10 @@ export class KWinWindow implements DriverWindow {
 
   public set minimized(min: boolean) {
     this.client.minimized = min;
+  }
+
+  public get shaded(): boolean {
+    return this.client.shade;
   }
 
   public maximized: boolean;

--- a/src/engine/window.ts
+++ b/src/engine/window.ts
@@ -86,6 +86,10 @@ export default class Window {
     return RectDelta.fromRects(this.geometry, this.actualGeometry);
   }
 
+  public get shaded(): boolean {
+    return this.window.shaded;
+  }
+
   public floatGeometry: Rect;
   public geometry: Rect;
   public timestamp: number;
@@ -112,6 +116,7 @@ export default class Window {
 
   public set state(value: WindowState) {
     const winState = this.state;
+    this.internalStatePreviouslyAskedToChangeTo = winState;
 
     /* cannot transit to the current state */
     if (winState === value) {
@@ -133,6 +138,10 @@ export default class Window {
     }
 
     this.internalState = value;
+  }
+
+  public get statePreviouslyAskedToChangeTo(): WindowState {
+    return this.internalStatePreviouslyAskedToChangeTo;
   }
 
   public get surface(): DriverSurface {
@@ -159,6 +168,7 @@ export default class Window {
   }
 
   private internalState: WindowState;
+  private internalStatePreviouslyAskedToChangeTo: WindowState;
   private shouldCommitFloat: boolean;
   private weightMap: { [key: string]: number };
 
@@ -169,6 +179,7 @@ export default class Window {
 
     this.id = window.id;
     this.window = window;
+    this.internalStatePreviouslyAskedToChangeTo = WindowState.Floating;
 
     this.floatGeometry = window.geometry;
     this.geometry = window.geometry;

--- a/src/extern/kwin.d.ts
+++ b/src/extern/kwin.d.ts
@@ -254,6 +254,16 @@ declare namespace KWin {
     onAllDesktops: boolean;
 
     /**
+     * Whether the Client is shaded.
+     */
+    shade: boolean;
+
+    /**
+     * Whether the window shading state changed
+     */
+    shadeChanged: QSignal;
+
+    /**
      * @see active
      */
     activeChanged: QSignal;


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Shaded windows are put to floating state and brought to their original state, once unshaded.

## Test Plan

### Tiled winodows
1. Shade tiled window. It should float.
2. Unshaded, the same window. It should be tiled.

### Floating windows
1. Shade floating window. Nothing should break
1. Unshade it. It should still be floated.

### Tiled windows with shade move
1. Shade tiled window, move it.
1. Unshade it, it should become tiled.

## Related Issues

Closes #65 
