### PR TITLE
fix: prevent hanging with Monocle and monocleMinimizeRest when closing modals

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -237,19 +237,17 @@ export class TilingController implements Controller {
     this.engine.arrange();
 
     // Switch to next window if monocle with config.monocleMinimizeRest
-    try {
-      if (!this.currentWindow && this.engine.isLayoutMonocleAndMinimizeRest()) {
-        this.engine.focusOrder(1, true);
-        /* HACK: force window to maximize if it isn't already
-         * This is ultimately to trigger onWindowFocused() at the right time
-         */
-        this.engine.focusOrder(1, true);
-        this.engine.focusOrder(-1, true);
-      }
-    } catch {
-      /* HACK for the HACK: transient modals cause an error with the above workaround,
-       * so if we catch it here and ignore it, all is well */
-      return;
+    if (
+      !window.window.isDialog &&
+      !this.currentWindow &&
+      this.engine.isLayoutMonocleAndMinimizeRest()
+    ) {
+      this.engine.focusOrder(1, true);
+      /* HACK: force window to maximize if it isn't already
+       * This is ultimately to trigger onWindowFocused() at the right time
+       */
+      this.engine.focusOrder(1, true);
+      this.engine.focusOrder(-1, true);
     }
   }
 
@@ -346,25 +344,29 @@ export class TilingController implements Controller {
   }
 
   public onWindowFocused(window: Window): void {
-    window.timestamp = new Date().getTime();
-    this.currentWindow = window;
-    // Minimize other windows if Monocle and config.monocleMinimizeRest
-    if (
-      this.engine.isLayoutMonocleAndMinimizeRest() &&
-      this.engine.windows.getVisibleTiles(window.surface).includes(window)
-    ) {
-      /* If a window hasn't been focused in this layout yet, ensure its geometry
-       * gets maximized.
-       */
-      this.engine
-        .currentLayoutOnCurrentSurface()
-        .apply(
-          this,
-          this.engine.windows.getAllTileables(window.surface),
-          window.surface.workingArea
-        );
+    try {
+      window.timestamp = new Date().getTime();
+      this.currentWindow = window;
+      // Minimize other windows if Monocle and config.monocleMinimizeRest
+      if (
+        this.engine.isLayoutMonocleAndMinimizeRest() &&
+        this.engine.windows.getVisibleTiles(window.surface).includes(window)
+      ) {
+        /* If a window hasn't been focused in this layout yet, ensure its geometry
+         * gets maximized.
+         */
+        this.engine
+          .currentLayoutOnCurrentSurface()
+          .apply(
+            this,
+            this.engine.windows.getAllTileables(window.surface),
+            window.surface.workingArea
+          );
 
-      this.engine.minimizeOthers(window);
+        this.engine.minimizeOthers(window);
+      }
+    } catch {
+      return;
     }
   }
 

--- a/src/driver/window.ts
+++ b/src/driver/window.ts
@@ -20,6 +20,7 @@ export interface DriverWindow {
   readonly shouldFloat: boolean;
   readonly screen: number;
   readonly active: boolean;
+  readonly isDialog: boolean;
   surface: DriverSurface;
   minimized: boolean;
 
@@ -252,5 +253,9 @@ export class KWinWindow implements DriverWindow {
     }
 
     return new Rect(geometry.x, geometry.y, width, height);
+  }
+
+  public get isDialog(): boolean {
+    return this.client.dialog;
   }
 }


### PR DESCRIPTION
## Summary

This is a simple fix that ~~wraps the offending part of `controller.onWindowRemoved()` in a `try/catch` block~~ adds an `isDialog()` getter to the `DriverWindow` interface and checks it before calling `controller.onWindowFocused()` from `controller.onWindowRemoved()`, and also wraps the body of `controller.onWindowFocused()` in a try/catch block. This prevents KWin from locking up when closing a modal in this context. There is probably a way to do it that doesn't involve exception/error handling, but this is the quickest way and keeps the modifications very localized.

## Breaking Changes

None

## UI Changes

None

## Test Plan

1. Reload Script after enabling monocleMinimizeRest
2. Enter Monocle layout and open a modal (Bismuth settings, Otter-browser settings, etc)
3. Try to close the modal
4. Should close gracefully and restore focus to parent

## Related Issues

Closes #110
