### PR TITLE
fix: :bug: do not tile utility windows on wayland

### DIFF
--- a/res/config/main.xml
+++ b/res/config/main.xml
@@ -62,7 +62,7 @@
 
     <entry name="ignoreClass" type="String">
 	    <label>Ignore windows with certain classes(comma-separated list)</label>
-        <default>krunner,yakuake,spectacle,kded5,Conky</default>
+        <default>yakuake,spectacle,Conky</default>
     </entry>
 
     <entry name="ignoreRole" type="String">

--- a/src/config.ts
+++ b/src/config.ts
@@ -238,10 +238,7 @@ export class ConfigImpl implements Config {
       this.kwinApi.KWin.readConfig("ignoreActivity", "")
     );
     this.ignoreClass = commaSeparate(
-      this.kwinApi.KWin.readConfig(
-        "ignoreClass",
-        "krunner,yakuake,spectacle,kded5,Conky"
-      )
+      this.kwinApi.KWin.readConfig("ignoreClass", "yakuake,spectacle,Conky")
     );
     this.ignoreRole = commaSeparate(
       this.kwinApi.KWin.readConfig("ignoreRole", "quake")

--- a/src/driver/window.ts
+++ b/src/driver/window.ts
@@ -55,6 +55,9 @@ export class KWinWindow implements DriverWindow {
     return (
       this.client.specialWindow ||
       resourceClass === "plasmashell" ||
+      resourceClass === "org.kde.plasmashell" ||
+      resourceClass === "krunner" ||
+      resourceClass === "kded5" ||
       this.config.ignoreClass.indexOf(resourceClass) >= 0 ||
       this.config.ignoreClass.indexOf(resourceName) >= 0 ||
       matchWords(this.client.caption, this.config.ignoreTitle) >= 0 ||


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Moved some classes from the config to the hardcode (they should never be configurable). Also added org.kde.plasmashell class to ignore list.

This still does not fix concurrency issues, but should help.

## Test Plan

1. Reload script
2. Open that window with new added classes (e.g. Activity Sidebar)
3. They should not be tiled.

## Related Issues

Closes #95 
