### PR TITLE
fix: add script to remove Plasma keyboard shortcuts

### DIFF
--- a/contrib/remove_keyboard_shortcuts.sh
+++ b/contrib/remove_keyboard_shortcuts.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+read -r -p "Do you want to remove Bitmuth's keyboard shortcuts? [Y/n] " response
+response=${response,,} # tolower
+if [[ $response =~ ^(yes|y| ) ]] || [[ -z $response ]]; then
+  sed -i -r 's/^bismuth.+//g' ~/.config/kglobalshortcutsrc
+  # remove the multiple newlines left by sed
+  sed -i -r ':a;N;$!ba;s/\n{3,}/\n\n/g' ~/.config/kglobalshortcutsrc
+fi


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Added script to remove Bismuth's keyboard shortcuts in ~/.config/kglobalshortcutsrc.

## Breaking Changes

Do your changes intentionally break something on the user side or configuration?
No.

## UI Changes

None.

## Test Plan

1. Run `sh remove_keyboard_shortcuts.sh`
2. Answer `y` to confirm.
3. The keyboard shortcuts in ~/.config/kglobalshortcutsrc should be gone.

## Related Issues

Closes #137
