### PR TITLE
fix: do not ignore second windows when resize

### DIFF
--- a/src/kwinscript/engine/layout/quarter_layout.ts
+++ b/src/kwinscript/engine/layout/quarter_layout.ts
@@ -56,7 +56,7 @@ export default class QuarterLayout implements WindowsLayout {
     if ((idx === 0 || idx === 3) && delta.east !== 0) {
       this.vsplit =
         (Math.floor(area.width * this.vsplit) + delta.east) / area.width;
-    } else if ((idx === 2 || idx === 2) && delta.west !== 0) {
+    } else if ((idx === 1 || idx === 2) && delta.west !== 0) {
       this.vsplit =
         (Math.floor(area.width * this.vsplit) - delta.west) / area.width;
     }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Simple bugfix

## Breaking Changes

None

## UI Changes

None

## Test Plan

1. Reload Script...
2. Put two windows side by side in quarter tiling
3. Both windows in quarter tiling should resize proprely

## Related Issues

Closes #135
