### PR TITLE
chore: publish build artifacts on release

### DIFF
--- a/.github/scripts/tar-build.sh
+++ b/.github/scripts/tar-build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+# SPDX-License-Identifier: MIT
+
+set -e
+
+tar czf build-artifacts.tar.gz --directory=build .

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,9 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Release Please 🔖
         uses: GoogleCloudPlatform/release-please-action@v2
@@ -20,3 +23,35 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
+
+  publish-artifacts:
+    name: Publish Artifacts
+    runs-on: ubuntu-latest
+    container: ubuntu:21.10
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
+      - name: Checkout Code 🛎️
+        uses: actions/checkout@v2
+
+      - name: Setup CI Utils ⚙️
+        run: .github/scripts/utils-install.sh
+
+      - name: Build 🔧
+        run: |
+          npm install
+          .github/scripts/sysdep-install.sh
+          npm run build
+
+      - name: Package 📦
+        run: |
+          .github/scripts/tar-build.sh
+
+      - name: Publish 🎉
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: |
+            build-artifacts.tar.gz


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Produce build artifacts after release and attach them to the GitHub release page. This helps packagers - they don't have to use NPM.

## Test Plan

Tested with another repo: https://github.com/gikari/test-bismuth-ci/releases/tag/v3.0.0

## Related Issues

Ref #152 
