### PR TITLE
fix: prevent broken tiling, by not including empty stings into rules

### DIFF
--- a/src/kwinscript/config.ts
+++ b/src/kwinscript/config.ts
@@ -129,7 +129,11 @@ export class ConfigImpl implements Config {
       if (!str || typeof str !== "string") {
         return [];
       }
-      return str.split(",").map((part) => part.trim());
+      // Split by commas, trim and remove empty strings
+      return str
+        .split(",")
+        .map((part) => part.trim())
+        .filter((i) => i);
     }
 
     this.kwinApi = kwinApi;


### PR DESCRIPTION
## Test Plan

1. Add a rule for the window, that will end with a comma, or will contain an empty string. Apply the settings.
2. Tiling should not be broken

## Related Issues

Closes #154 
