### PR TITLE
chore: remove file specific rules from the .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,3 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
-
-[*.qml]
-indent_style = space
-indent_size = 2


### PR DESCRIPTION
Also sets the default character set to UTF-8 and 4 space indentation. Files included in the second block will have 2 space indentation.

Note: Currently, all the QML files have 4 space indentation. I am not sure if that's intentional, thus I haven't removed the `*.qml` pattern.