### PR TITLE
feat: add a shortcut for the reverse rotation action

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ package](https://aur.archlinux.org/packages/kwin-bismuth) with your favorite
 AUR helper.
 
 #### Gentoo
+
 Updated ebuilds provided in [viperML-overlay](https://github.com/viperML/viperML-overlay/).
 
 #### Other distributions
@@ -123,4 +124,5 @@ You can configure Bismuth in the System Settings > Window Management > Window Ti
 | Set Quarter Layout                | _None_           |
 |                                   |                  |
 | Rotate                            | Meta + R         |
+| Rotate (Reverse)                  | _None_           |
 | Rotate Part                       | Meta + Shift + R |

--- a/src/kwinscript/controller/action.ts
+++ b/src/kwinscript/controller/action.ts
@@ -571,6 +571,16 @@ export class Rotate extends ActionImpl implements Action {
   }
 }
 
+export class RotateReverse extends ActionImpl implements Action {
+  constructor(protected engine: Engine, protected log: Log) {
+    super(engine, "rotate_reverse", "Rotate (Reverse)", "", log);
+  }
+
+  public executeWithoutLayoutOverride(): void {
+    this.engine.showNotification("Rotation Not Applicable");
+  }
+}
+
 export class RotatePart extends ActionImpl implements Action {
   constructor(protected engine: Engine, protected log: Log) {
     super(engine, "rotate_part", "Rotate Part", "Meta+Shift+R", log);

--- a/src/kwinscript/controller/index.ts
+++ b/src/kwinscript/controller/index.ts
@@ -433,6 +433,7 @@ export class ControllerImpl implements Controller {
       new Action.ToggleQuarterLayout(this.engine, this.log),
 
       new Action.Rotate(this.engine, this.log),
+      new Action.RotateReverse(this.engine, this.log),
       new Action.RotatePart(this.engine, this.log),
     ];
 

--- a/src/kwinscript/engine/layout/tile_layout.ts
+++ b/src/kwinscript/engine/layout/tile_layout.ts
@@ -19,6 +19,7 @@ import {
   IncreaseLayoutMasterAreaSize,
   IncreaseMasterAreaWindowCount,
   Rotate,
+  RotateReverse,
   RotatePart,
 } from "../../controller/action";
 
@@ -132,6 +133,8 @@ export default class TileLayout implements WindowsLayout {
       engine.showLayoutNotification();
     } else if (action instanceof Rotate) {
       this.parts.rotate(90);
+    } else if (action instanceof RotateReverse) {
+      this.parts.rotate(-90);
     } else if (action instanceof RotatePart) {
       this.parts.inner.primary.rotate(90);
     } else {


### PR DESCRIPTION
Adds a shortcut for rotating the layout in a reversed direction. Unbound by default.