### PR TITLE
feat: add custom icons for the OSD popup

### DIFF
--- a/src/kwinscript/CMakeLists.txt
+++ b/src/kwinscript/CMakeLists.txt
@@ -19,6 +19,8 @@ set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 include(KDEInstallDirs)
 include(KDECMakeSettings)
 
+include(ECMInstallIcons)
+
 add_custom_target(
   KWinScript ALL
   COMMENT "🏗️ Building KWin Script..."
@@ -57,3 +59,5 @@ install(
   DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bismuth"
   DESTINATION "${KDE_INSTALL_DATAROOTDIR}/kwin/scripts"
 )
+
+add_subdirectory(icons)

--- a/src/kwinscript/icons/32-status-bismuth-column.svg
+++ b/src/kwinscript/icons/32-status-bismuth-column.svg
@@ -1,0 +1,19 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <style id="current-color-scheme" type="text/css">
+  .ColorScheme-Text { color:#eff0f1; }
+ </style>
+ <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
+  <rect x="1.3636" y="5.2" width="9.5455" height="21.6" stroke-width=".76376"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
+  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="13.636" y="5.2" width="10.909" height="21.6" stroke-width=".81649"/>
+  <rect x="27.273" y="5.2001" width="9.5455" height="21.6" stroke-width=".76376"/>
+ </g>
+</svg>

--- a/src/kwinscript/icons/32-status-bismuth-floating.svg
+++ b/src/kwinscript/icons/32-status-bismuth-floating.svg
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <style id="current-color-scheme" type="text/css">
+  .ColorScheme-Text { color:#eff0f1; }
+ </style>
+ <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
+  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
+  <path d="m15 5.2v6h9.5455v8.4h12.273v-14.4z" stroke-width=".95742"/>
+  <rect x="1.3636" y="12.4" width="21.818" height="14.4" stroke-width=".9428"/>
+ </g>
+</svg>

--- a/src/kwinscript/icons/32-status-bismuth-monocle.svg
+++ b/src/kwinscript/icons/32-status-bismuth-monocle.svg
@@ -1,0 +1,17 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <style id="current-color-scheme" type="text/css">
+  .ColorScheme-Text { color:#eff0f1; }
+ </style>
+ <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
+  <rect x="1.3636" y="5.2" width="35.455" height="21.6" stroke-width="1.472"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
+  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
+ </g>
+</svg>

--- a/src/kwinscript/icons/32-status-bismuth-quarter.svg
+++ b/src/kwinscript/icons/32-status-bismuth-quarter.svg
@@ -1,0 +1,20 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <style id="current-color-scheme" type="text/css">
+  .ColorScheme-Text { color:#eff0f1; }
+ </style>
+ <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
+  <rect x="1.3636" y="17.2" width="16.364" height="9.6" stroke-width=".66667"/>
+  <rect x="20.455" y="5.2" width="16.364" height="9.6"/>
+  <rect x="20.455" y="17.2" width="16.364" height="9.6"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
+  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="1.3636" y="5.2" width="16.364" height="9.6" stroke-width=".66667"/>
+ </g>
+</svg>

--- a/src/kwinscript/icons/32-status-bismuth-spiral.svg
+++ b/src/kwinscript/icons/32-status-bismuth-spiral.svg
@@ -1,0 +1,20 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <style id="current-color-scheme" type="text/css">
+  .ColorScheme-Text { color:#eff0f1; }
+ </style>
+ <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
+  <rect x="1.3636" y="5.2" width="16.364" height="21.6"/>
+  <rect x="20.455" y="5.2" width="16.364" height="9.6"/>
+  <rect x="20.455" y="17.2" width="6.8179" height="9.6" stroke-width=".64547"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
+  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="30" y="17.2" width="6.8189" height="9.6" stroke-width=".64552"/>
+ </g>
+</svg>

--- a/src/kwinscript/icons/32-status-bismuth-spread.svg
+++ b/src/kwinscript/icons/32-status-bismuth-spread.svg
@@ -1,0 +1,19 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <style id="current-color-scheme" type="text/css">
+  .ColorScheme-Text { color:#eff0f1; }
+ </style>
+ <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
+  <rect x="1.3636" y="5.2" width="30" height="21.6" stroke-width="1.354"/>
+  <rect x="32.727" y="5.2" width="1.3643" height="21.6" stroke-width=".43311"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
+  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="35.455" y="5.2" width="1.3643" height="21.6" stroke-width=".43311"/>
+ </g>
+</svg>

--- a/src/kwinscript/icons/32-status-bismuth-stair.svg
+++ b/src/kwinscript/icons/32-status-bismuth-stair.svg
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <style id="current-color-scheme" type="text/css">
+  .ColorScheme-Text { color:#eff0f1; }
+ </style>
+ <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
+  <rect x="1.3636" y="7.6" width="32.727" height="19.2" stroke-width="1.3333"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
+  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
+  <path d="m2.7273 5.2v1.2h32.727v19.2h1.3636v-20.4z" stroke-width="1.4027"/>
+ </g>
+</svg>

--- a/src/kwinscript/icons/32-status-bismuth-tile.svg
+++ b/src/kwinscript/icons/32-status-bismuth-tile.svg
@@ -1,0 +1,19 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <style id="current-color-scheme" type="text/css">
+  .ColorScheme-Text { color:#eff0f1; }
+ </style>
+ <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
+  <rect x="1.3636" y="5.2" width="16.364" height="21.6"/>
+  <rect x="20.455" y="5.2" width="16.364" height="9.6"/>
+  <rect x="20.455" y="17.2" width="16.364" height="9.6"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
+  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
+  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
+  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
+ </g>
+</svg>

--- a/src/kwinscript/icons/CMakeLists.txt
+++ b/src/kwinscript/icons/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+# SPDX-License-Identifier: MIT
+
+ecm_install_icons(
+  ICONS
+  32-status-bismuth-column.svg
+  32-status-bismuth-floating.svg
+  32-status-bismuth-monocle.svg
+  32-status-bismuth-quarter.svg
+  32-status-bismuth-spiral.svg
+  32-status-bismuth-spread.svg
+  32-status-bismuth-stair.svg
+  32-status-bismuth-tile.svg
+  DESTINATION ${KDE_INSTALL_ICONDIR}
+)


### PR DESCRIPTION
## Summary

Adds an icon to the OSD popup that appears when switching layouts.

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| ![before](https://user-images.githubusercontent.com/28950897/140795856-86fb2b25-4349-478e-9ced-6fb83d90d945.jpg) | ![after](https://user-images.githubusercontent.com/28950897/140795901-63d54ae5-bbdb-4885-ae80-aee7dec66b5c.gif) |

## Test Plan

1. Reinstall Bismuth.
2. Restart KWin.
3. Switch between layouts.

## Related Issues

Closes #129
