### PR TITLE
Avoid usage of npx

### DIFF
--- a/src/kwinscript/CMakeLists.txt
+++ b/src/kwinscript/CMakeLists.txt
@@ -29,7 +29,7 @@ add_custom_target(
 
 add_custom_command(
   OUTPUT "bismuth/contents/code/index.mjs"
-  COMMAND "npx" "esbuild"
+  COMMAND "esbuild"
   "--bundle" "${CMAKE_CURRENT_SOURCE_DIR}/index.ts"
   "--outfile=${CMAKE_CURRENT_BINARY_DIR}/bismuth/contents/code/index.mjs"
   "--format=esm"
@@ -40,7 +40,7 @@ add_custom_command(
 
 add_custom_target(
   LintViaTSC
-  COMMAND "npx" "tsc" "--noEmit" "--incremental"
+  COMMAND "tsc" "--noEmit" "--incremental"
   COMMENT "👮 Checking sources using TS Compiler..."
 )
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

NPX requires internet access that many build system deny access to. This pr ensures that instead cmake uses the globally installed esbuild and tsc.

## Breaking Changes

Do your changes intentionally break something on the user side or configuration?

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| Screenshot of UI before change | Screenshot of UI after change |

## Test Plan

1. Reload Script...
2. ...
3. Something happens

## Related Issues

Closes #X
