### PR TITLE
Enable/disable script from the KCM

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,5 +10,5 @@ echo "📦 Installing Bismuth..."
 sudo cmake --install "build"
 
 echo "🎉 Installation finished."
-echo "💡 You can configure Bismuth in the System Settings > Window Management > Window Tiling."
-echo "🦾 Enjoy your tiling!"
+echo "💡 You can enable and configure window tiling in the System Settings > Window Management > Window Tiling."
+echo "🦾 Don't forget to enable window tiling. We hope you will enjoy it!"

--- a/src/kcm/bismuth_config.kcfg
+++ b/src/kcm/bismuth_config.kcfg
@@ -180,5 +180,13 @@
       <default>false</default>
     </entry>
   </group>
+
+  <group name="Plugins">
+    <entry name="bismuthEnabled" type="Bool">
+      <label>Enable Bismuth KWin Script component</label>
+      <!-- This is KWin default, we could not change that -->
+      <default>false</default>
+    </entry>
+  </group>
 </kcfg>
 

--- a/src/kcm/package/contents/ui/Behaviour.qml
+++ b/src/kcm/package/contents/ui/Behaviour.qml
@@ -14,6 +14,16 @@ Kirigami.FormLayout {
 
     Item {
         Kirigami.FormData.isSection: true
+        Kirigami.FormData.label: i18n("General")
+    }
+
+    BIC.ConfigCheckBox {
+        settingName: "bismuthEnabled"
+        text: i18n("Enable window tiling")
+    }
+
+    Item {
+        Kirigami.FormData.isSection: true
         Kirigami.FormData.label: i18n("Layouts")
     }
 

--- a/src/kcm/package/contents/ui/main.qml
+++ b/src/kcm/package/contents/ui/main.qml
@@ -31,11 +31,11 @@ KCM.SimpleKCM {
             Layout.bottomMargin: -1
 
             QQC2.TabButton {
-                text: i18n("Appearance")
+                text: i18n("Behavior")
             }
 
             QQC2.TabButton {
-                text: i18n("Behavior")
+                text: i18n("Appearance")
             }
 
         }
@@ -51,12 +51,12 @@ KCM.SimpleKCM {
                 // but necessary for adequate padding
                 anchors.topMargin: Kirigami.Units.gridUnit * -0.5
 
-                Appearance {
-                }
-
                 // For some reason QML is very British and
                 // refuses to load the Behavior.qml (without "u")
                 Behaviour {
+                }
+
+                Appearance {
                 }
 
             }


### PR DESCRIPTION
## Summary

Now the behavior tab is the first, as the important option is here. We could enable script by default, but this will result in a potentially unpleasant surprise for the end user ("I installed the package, why is everything got wonky?"). When the user enables the tiling explicitly, they get the answer to this question more intuitively and will be immediately presented with an option to disable it, if something goes wrong ("Oh, I enabled the script, windows got places, that's why. Maybe it's not that great, I will disable the tiling then"),

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| ![Screenshot_20211110_182938](https://user-images.githubusercontent.com/14205339/141142218-66729217-7b51-48cd-87e8-657aee5950de.png) | ![Screenshot_20211110_182841](https://user-images.githubusercontent.com/14205339/141142051-ea85dabd-9f3d-455b-bd36-4af8c85785f0.png) |

This is essentially the KWin Scripts checkbox, but the end user should not know about the fact, that the Bismuth and window tiling in general has a KWin Script component. I,e. there are no two places, where the settings are located (ideally the Bismuth should be hidden within this list, but it's not possible to do that)

## Test Plan

1. Install the PR version
2. Open the settings and try to toggle the new checkbox on and off
3. Bismuth should be enabled and disabled accordingly.

## Related Issues

Closes #179 
