### PR TITLE
chore: replace KCM icon

### DIFF
--- a/LICENSES/LGPL-3.0-or-later.txt
+++ b/LICENSES/LGPL-3.0-or-later.txt
@@ -1,0 +1,71 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
+
+0. Additional Definitions.
+
+As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
+
+"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
+
+An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
+
+A "Combined Work" is a work produced by combining or linking an Application with the Library.  The particular version of the Library with which the Combined Work was made is also called the "Linked Version".
+
+The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
+
+1. Exception to Section 3 of the GNU GPL.
+You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+
+2. Conveying Modified Versions.
+If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
+
+     a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
+
+     b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+The object code form of an Application may incorporate material from a header file that is part of the Library.  You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
+
+     a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
+
+     b) Accompany the object code with a copy of the GNU GPL and this license document.
+
+4. Combined Works.
+You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
+
+     a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
+
+     b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+
+     c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+
+     d) Do one of the following:
+
+           0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
+
+          1) Use a suitable shared library mechanism for linking with the Library.  A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
+
+     e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+
+5. Combined Libraries.
+You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
+
+     b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.

--- a/src/kcm/icons/22-categories-bismuth-kcm.svg
+++ b/src/kcm/icons/22-categories-bismuth-kcm.svg
@@ -1,0 +1,45 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
+<svg version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <linearGradient id="b">
+   <stop stop-color="#c6cdd1" offset="0"/>
+   <stop stop-color="#e0e5e7" offset="1"/>
+  </linearGradient>
+  <linearGradient id="d" x1="391.57" x2="406.57" y1="525.8" y2="540.8" gradientTransform="translate(282.55 -343.68)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+  <linearGradient id="c">
+   <stop offset="0"/>
+   <stop stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="a" x2="0" y1="543.8" y2="502.66" gradientTransform="matrix(.66667 0 0 .63518 128.19 198.52)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
+  <linearGradient id="f" x1="379.57" x2="407.57" y1="540.8" y2="555.8" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+  <linearGradient id="e" x1="392.57" x2="401.57" y1="524.8" y2="539.8" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+  <linearGradient id="g" x2="0" y1="543.8" y2="502.66" gradientTransform="matrix(.66667 0 0 .63518 128.19 198.52)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
+ </defs>
+ <g transform="translate(-352.57 -511.8)">
+  <rect x="386.57" y="517.8" width="30" height="24" rx="0" fill="url(#a)"/>
+  <path d="m387.57 539.8 28-16 1 1v17h-27z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
+  <rect x="386.57" y="517.8" width="30" height="4" fill="#566069"/>
+  <rect x="386.57" y="521.8" width="30" height="1" fill="#3daee9"/>
+  <rect x="387.57" y="523.8" width="28" height="16" fill="#fff"/>
+  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+ </g>
+ <g transform="translate(-385.57 -511.8)">
+  <rect x="385.57" y="517.8" width="30" height="52" rx="0" fill="url(#a)"/>
+  <path d="m386.57 567.8 28-44 1 1v45h-27z" fill="url(#f)" fill-rule="evenodd" opacity=".2"/>
+  <rect x="385.57" y="517.8" width="30" height="4" fill="#566069"/>
+  <rect x="385.57" y="521.8" width="30" height="1" fill="#3daee9"/>
+  <rect x="386.57" y="523.8" width="28" height="44" fill="#fff"/>
+  <rect x="412.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+ </g>
+ <g transform="translate(-352.57 -483.8)">
+  <rect x="386.57" y="517.8" width="30" height="24" rx="0" fill="url(#g)"/>
+  <path d="m387.57 539.8 28-16 1 1v17h-27z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
+  <rect x="386.57" y="517.8" width="30" height="4" fill="#566069"/>
+  <rect x="386.57" y="521.8" width="30" height="1" fill="#3daee9"/>
+  <rect x="387.57" y="523.8" width="28" height="16" fill="#fff"/>
+  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+ </g>
+</svg>

--- a/src/kcm/icons/64-categories-bismuth-kcm.svg
+++ b/src/kcm/icons/64-categories-bismuth-kcm.svg
@@ -1,0 +1,44 @@
+<!--
+SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
+<svg version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <linearGradient id="b">
+   <stop stop-color="#c6cdd1" offset="0"/>
+   <stop stop-color="#e0e5e7" offset="1"/>
+  </linearGradient>
+  <linearGradient id="d" x1="391.57" x2="406.57" y1="525.8" y2="540.8" gradientTransform="translate(282.55 -343.68)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+  <linearGradient id="c">
+   <stop offset="0"/>
+   <stop stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="a" x2="0" y1="543.8" y2="502.66" gradientTransform="matrix(.66667 0 0 .63518 128.19 198.52)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
+  <linearGradient id="e" x1="391.57" x2="400.03" y1="525.8" y2="540.6" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+  <linearGradient id="f" x1="380.4" x2="408.72" y1="541.17" y2="556.25" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+ </defs>
+ <g transform="translate(-352.57 -511.8)">
+  <rect x="385.57" y="517.8" width="31" height="25" rx="0" fill="url(#a)"/>
+  <path d="m386.57 540.8 29-17 1 1-2e-5 18h-28z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
+  <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
+  <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
+  <rect x="386.57" y="523.8" width="29" height="17" fill="#fff"/>
+  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+ </g>
+ <g transform="translate(-352.57 -484.8)">
+  <rect x="385.57" y="517.8" width="31" height="25" rx="0" fill="url(#a)"/>
+  <path d="m386.57 540.8 29-17 1 1-2e-5 18h-28z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
+  <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
+  <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
+  <rect x="386.57" y="523.8" width="29" height="17" fill="#fff"/>
+  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+ </g>
+ <g transform="translate(-385.57 -511.8)">
+  <rect x="385.57" y="517.8" width="31" height="52" rx="0" fill="url(#a)"/>
+  <path d="m386.57 567.8 29-44 1 1-2e-5 45h-28z" fill="url(#f)" fill-rule="evenodd" opacity=".2"/>
+  <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
+  <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
+  <rect x="386.57" y="523.8" width="29" height="44" fill="#fff"/>
+  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+ </g>
+</svg>

--- a/src/kcm/icons/CMakeLists.txt
+++ b/src/kcm/icons/CMakeLists.txt
@@ -4,5 +4,7 @@
 ecm_install_icons(
   ICONS
   sc-apps-bismuth.svg
+  22-categories-bismuth-kcm.svg
+  64-categories-bismuth-kcm.svg
   DESTINATION ${KDE_INSTALL_ICONDIR}
 )

--- a/src/kcm/package/metadata.desktop
+++ b/src/kcm/package/metadata.desktop
@@ -4,10 +4,10 @@
 
 [Desktop Entry]
 Name=Window Tiling
-Comment=Configure Window Tiling specific options
+Comment=Configure window tiling appearance and behavior
 Encoding=UTF-8
 Type=Service
-Icon=bismuth
+Icon=bismuth-kcm
 X-KDE-Library=kcm_bismuth
 X-KDE-ServiceTypes=KCModule
 X-KDE-FormFactors=desktop,handset,tablet,mediacenter


### PR DESCRIPTION
## Summary

Replaces KCM icon with something more suitable. 

Based on the Breeze icon theme:
https://develop.kde.org/frameworks/breeze-icons

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| ![before_dark](https://user-images.githubusercontent.com/28950897/141324133-8c50c1c5-8612-4b0d-ad92-dccb706d5bbb.png) | ![dark](https://user-images.githubusercontent.com/28950897/141323507-6ae5df60-49e8-4114-8c4a-082c4525c323.png) |
