### PR TITLE
chore: launch system settings at the end of the installation process

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,23 @@ echo "📦 Installing Bismuth..."
 
 sudo cmake --install "build"
 
+echo ""
 echo "🎉 Installation finished."
-echo "💡 You can enable and configure window tiling in the System Settings > Window Management > Window Tiling."
-echo "🦾 Don't forget to enable window tiling. We hope you will enjoy it!"
+echo ""
+echo "💡 You can now enable and configure Bismuth in the System Settings → Window Management → Window Tiling."
+echo "🦾 "$(tput bold)"Don't forget to enable window tiling."$(tput sgr0)" We hope you will enjoy it!"
+
+if command -v systemsettings5 > /dev/null; then
+  systemsettings5 kcm_bismuth > /dev/null 2>&1 &
+  exit 0
+fi
+
+if command -v systemsettings > /dev/null; then
+  systemsettings kcm_bismuth > /dev/null 2>&1 &
+  exit 0
+fi
+
+if command -v kcmshell5 > /dev/null; then
+  kcmshell5 kcm_bismuth > /dev/null 2>&1 &
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Opens Bismuth's configuration view in the system settings at the end of the installation process.