### PR TITLE
fix: provide a backend for custom icons in the OSD popup

### DIFF
--- a/src/kwinscript/controller/index.ts
+++ b/src/kwinscript/controller/index.ts
@@ -40,11 +40,11 @@ export interface Controller {
 
   /**
    * Show a popup notification in the center of the screen.
-   * @param text the text of the notification.
-   * @param text2 optional string displayed to the right of the main text.
-   * @param icon optional name of the icon to display in the popup.
+   * @param text the main text of the notification.
+   * @param icon an optional name of the icon to display in the pop-up.
+   * @param hint an optional string displayed beside the main text.
    */
-  showNotification(text: string, text2?: string, icon?: string): void;
+  showNotification(text: string, icon?: string, hint?: string): void;
 
   /**
    * React to screen focus change
@@ -202,8 +202,8 @@ export class ControllerImpl implements Controller {
     this.driver.currentSurface = value;
   }
 
-  public showNotification(text: string, text2?: string, icon?: string): void {
-    this.driver.showNotification(text, text2, icon);
+  public showNotification(text: string, icon?: string, hint?: string): void {
+    this.driver.showNotification(text, icon, hint);
   }
 
   public onSurfaceUpdate(comment: string): void {

--- a/src/kwinscript/controller/index.ts
+++ b/src/kwinscript/controller/index.ts
@@ -40,9 +40,11 @@ export interface Controller {
 
   /**
    * Show a popup notification in the center of the screen.
-   * @param text notification text
+   * @param text the text of the notification.
+   * @param text2 optional string displayed to the right of the main text.
+   * @param icon optional name of the icon to display in the popup.
    */
-  showNotification(text: string): void;
+  showNotification(text: string, text2?: string, icon?: string): void;
 
   /**
    * React to screen focus change
@@ -200,8 +202,8 @@ export class ControllerImpl implements Controller {
     this.driver.currentSurface = value;
   }
 
-  public showNotification(text: string): void {
-    this.driver.showNotification(text);
+  public showNotification(text: string, text2?: string, icon?: string): void {
+    this.driver.showNotification(text, text2, icon);
   }
 
   public onSurfaceUpdate(comment: string): void {

--- a/src/kwinscript/driver/index.ts
+++ b/src/kwinscript/driver/index.ts
@@ -38,12 +38,12 @@ export interface Driver {
   currentWindow: EngineWindow | null;
 
   /**
-   * Show notification to the user
-   * @param text the text of the notification.
-   * @param text2 optional string displayed to the right of the main text.
-   * @param icon optional name of the icon to display in the popup.
+   * Show a popup notification in the center of the screen.
+   * @param text the main text of the notification.
+   * @param icon an optional name of the icon to display in the pop-up.
+   * @param hint an optional string displayed beside the main text.
    */
-  showNotification(text: string, text2?: string, icon?: string): void;
+  showNotification(text: string, icon?: string, hint?: string): void;
 
   /**
    * Bind script to the various KWin events
@@ -317,8 +317,8 @@ export class DriverImpl implements Driver {
     this.controller.manageWindow(window);
   }
 
-  public showNotification(text: string, text2?: string, icon?: string): void {
-    this.qml.popupDialog.show(text, text2, icon);
+  public showNotification(text: string, icon?: string, hint?: string): void {
+    this.qml.popupDialog.show(text, icon, hint);
   }
 
   public bindShortcut(action: Action): void {

--- a/src/kwinscript/driver/index.ts
+++ b/src/kwinscript/driver/index.ts
@@ -39,9 +39,11 @@ export interface Driver {
 
   /**
    * Show notification to the user
-   * @param text notification text
+   * @param text the text of the notification.
+   * @param text2 optional string displayed to the right of the main text.
+   * @param icon optional name of the icon to display in the popup.
    */
-  showNotification(text: string): void;
+  showNotification(text: string, text2?: string, icon?: string): void;
 
   /**
    * Bind script to the various KWin events
@@ -315,8 +317,8 @@ export class DriverImpl implements Driver {
     this.controller.manageWindow(window);
   }
 
-  public showNotification(text: string): void {
-    this.qml.popupDialog.show(text);
+  public showNotification(text: string, text2?: string, icon?: string): void {
+    this.qml.popupDialog.show(text, text2, icon);
   }
 
   public bindShortcut(action: Action): void {

--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -161,9 +161,11 @@ export interface Engine {
 
   /**
    * Show the notification to the user
-   * @param text the text of the notification
+   * @param text the text of the notification.
+   * @param text2 optional string displayed to the right of the main text.
+   * @param icon optional name of the icon to display in the popup.
    */
-  showNotification(text: string): void;
+  showNotification(text: string, text2?: string, icon?: string): void;
 
   /**
    * Show the notification with the info
@@ -697,19 +699,17 @@ export class EngineImpl implements Engine {
     return closest.sort((a, b) => b.timestamp - a.timestamp)[0];
   }
 
-  public showNotification(text: string): void {
-    this.controller.showNotification(text);
+  public showNotification(text: string, text2?: string, icon?: string): void {
+    this.controller.showNotification(text, text2, icon);
   }
 
   public showLayoutNotification(): void {
     const currentLayout = this.currentLayoutOnCurrentSurface();
-    if (currentLayout.hint) {
-      this.controller.showNotification(
-        currentLayout.name + " [" + currentLayout.hint + "]"
-      );
-    } else {
-      this.controller.showNotification(currentLayout.name);
-    }
+    this.controller.showNotification(
+      currentLayout.name,
+      currentLayout.hint,
+      currentLayout.icon
+    );
   }
 
   /**

--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -160,12 +160,12 @@ export interface Engine {
   isLayoutMonocleAndMinimizeRest(): boolean;
 
   /**
-   * Show the notification to the user
-   * @param text the text of the notification.
-   * @param text2 optional string displayed to the right of the main text.
-   * @param icon optional name of the icon to display in the popup.
+   * Show a popup notification in the center of the screen.
+   * @param text the main text of the notification.
+   * @param icon an optional name of the icon to display in the pop-up.
+   * @param hint an optional string displayed beside the main text.
    */
-  showNotification(text: string, text2?: string, icon?: string): void;
+  showNotification(text: string, icon?: string, hint?: string): void;
 
   /**
    * Show the notification with the info
@@ -699,16 +699,16 @@ export class EngineImpl implements Engine {
     return closest.sort((a, b) => b.timestamp - a.timestamp)[0];
   }
 
-  public showNotification(text: string, text2?: string, icon?: string): void {
-    this.controller.showNotification(text, text2, icon);
+  public showNotification(text: string, icon?: string, hint?: string): void {
+    this.controller.showNotification(text, icon, hint);
   }
 
   public showLayoutNotification(): void {
     const currentLayout = this.currentLayoutOnCurrentSurface();
     this.controller.showNotification(
       currentLayout.name,
-      currentLayout.hint,
-      currentLayout.icon
+      currentLayout.icon,
+      currentLayout.hint
     );
   }
 

--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -703,7 +703,13 @@ export class EngineImpl implements Engine {
 
   public showLayoutNotification(): void {
     const currentLayout = this.currentLayoutOnCurrentSurface();
-    this.controller.showNotification(`Layout: ${currentLayout.description}`);
+    if (currentLayout.hint) {
+      this.controller.showNotification(
+        currentLayout.name + " [" + currentLayout.hint + "]"
+      );
+    } else {
+      this.controller.showNotification(currentLayout.name);
+    }
   }
 
   /**

--- a/src/kwinscript/engine/layout/cascade_layout.ts
+++ b/src/kwinscript/engine/layout/cascade_layout.ts
@@ -30,6 +30,8 @@ export enum CascadeDirection {
 
 export default class CascadeLayout implements WindowsLayout {
   public static readonly id = "CascadeLayout";
+  public readonly classID = CascadeLayout.id;
+  public readonly name = "Cascade Layout";
 
   /** Decompose direction into vertical and horizontal steps */
   public static decomposeDirection(
@@ -55,10 +57,8 @@ export default class CascadeLayout implements WindowsLayout {
     }
   }
 
-  public readonly classID = CascadeLayout.id;
-
-  public get description(): string {
-    return `Cascade [${CascadeDirection[this.dir]}]`;
+  public get hint(): string {
+    return String(CascadeDirection[this.dir]);
   }
 
   constructor(private dir: CascadeDirection = CascadeDirection.SouthEast) {

--- a/src/kwinscript/engine/layout/cascade_layout.ts
+++ b/src/kwinscript/engine/layout/cascade_layout.ts
@@ -32,6 +32,7 @@ export default class CascadeLayout implements WindowsLayout {
   public static readonly id = "CascadeLayout";
   public readonly classID = CascadeLayout.id;
   public readonly name = "Cascade Layout";
+  public readonly icon = "bismuth-cascade";
 
   /** Decompose direction into vertical and horizontal steps */
   public static decomposeDirection(

--- a/src/kwinscript/engine/layout/floating_layout.ts
+++ b/src/kwinscript/engine/layout/floating_layout.ts
@@ -15,6 +15,7 @@ export default class FloatingLayout implements WindowsLayout {
   public static instance = new FloatingLayout();
   public readonly classID = FloatingLayout.id;
   public readonly name = "Floating Layout";
+  public readonly icon = "bismuth-floating";
 
   public apply(
     _controller: Controller,

--- a/src/kwinscript/engine/layout/floating_layout.ts
+++ b/src/kwinscript/engine/layout/floating_layout.ts
@@ -13,9 +13,8 @@ import { Controller } from "../../controller";
 export default class FloatingLayout implements WindowsLayout {
   public static readonly id = "FloatingLayout ";
   public static instance = new FloatingLayout();
-
   public readonly classID = FloatingLayout.id;
-  public readonly description: string = "Floating";
+  public readonly name = "Floating Layout";
 
   public apply(
     _controller: Controller,

--- a/src/kwinscript/engine/layout/index.ts
+++ b/src/kwinscript/engine/layout/index.ts
@@ -18,9 +18,10 @@ export interface WindowsLayoutClass {
 }
 
 export interface WindowsLayout {
-  readonly capacity?: number;
   readonly name: string;
+  readonly icon: string;
   readonly hint?: string;
+  readonly capacity?: number;
 
   adjust?(
     area: Rect,

--- a/src/kwinscript/engine/layout/index.ts
+++ b/src/kwinscript/engine/layout/index.ts
@@ -18,6 +18,13 @@ export interface WindowsLayoutClass {
 }
 
 export interface WindowsLayout {
+  /**
+   * Windows layout
+   * @param name human readable name of the layout.
+   * @param icon the name of the icon of the layout.
+   * @param hint an optional string that can be used to indicate the number of master windows in the layout.
+   * @param capacity an optional maximum number of windows that the layout can contain.
+   */
   readonly name: string;
   readonly icon: string;
   readonly hint?: string;

--- a/src/kwinscript/engine/layout/index.ts
+++ b/src/kwinscript/engine/layout/index.ts
@@ -19,7 +19,8 @@ export interface WindowsLayoutClass {
 
 export interface WindowsLayout {
   readonly capacity?: number;
-  readonly description: string;
+  readonly name: string;
+  readonly hint?: string;
 
   adjust?(
     area: Rect,

--- a/src/kwinscript/engine/layout/index.ts
+++ b/src/kwinscript/engine/layout/index.ts
@@ -18,16 +18,27 @@ export interface WindowsLayoutClass {
 }
 
 export interface WindowsLayout {
+  /* read-only */
+
   /**
-   * Windows layout
-   * @param name human readable name of the layout.
-   * @param icon the name of the icon of the layout.
-   * @param hint an optional string that can be used to indicate the number of master windows in the layout.
-   * @param capacity an optional maximum number of windows that the layout can contain.
+   * Human-readable name of the layout.
    */
   readonly name: string;
+
+  /**
+   * The icon name of the layout.
+   */
   readonly icon: string;
+
+  /**
+   * A string that can be used to show layout specific properties in the pop-up,
+   * e.g. the number of master windows.
+   */
   readonly hint?: string;
+
+  /**
+   * The maximum number of windows, that the layout can contain.
+   */
   readonly capacity?: number;
 
   adjust?(

--- a/src/kwinscript/engine/layout/monocle_layout.ts
+++ b/src/kwinscript/engine/layout/monocle_layout.ts
@@ -24,9 +24,8 @@ import { Engine } from "..";
 
 export default class MonocleLayout implements WindowsLayout {
   public static readonly id = "MonocleLayout";
-  public readonly description: string = "Monocle";
-
   public readonly classID = MonocleLayout.id;
+  public readonly name = "Monocle Layout";
 
   private config: Config;
 

--- a/src/kwinscript/engine/layout/monocle_layout.ts
+++ b/src/kwinscript/engine/layout/monocle_layout.ts
@@ -26,6 +26,7 @@ export default class MonocleLayout implements WindowsLayout {
   public static readonly id = "MonocleLayout";
   public readonly classID = MonocleLayout.id;
   public readonly name = "Monocle Layout";
+  public readonly icon = "bismuth-monocle";
 
   private config: Config;
 

--- a/src/kwinscript/engine/layout/quarter_layout.ts
+++ b/src/kwinscript/engine/layout/quarter_layout.ts
@@ -17,6 +17,7 @@ export default class QuarterLayout implements WindowsLayout {
   public static readonly id = "QuarterLayout";
   public readonly classID = QuarterLayout.id;
   public readonly name = "Quarter Layout";
+  public readonly icon = "bismuth-quarter";
 
   public get capacity(): number {
     return 4;

--- a/src/kwinscript/engine/layout/quarter_layout.ts
+++ b/src/kwinscript/engine/layout/quarter_layout.ts
@@ -15,9 +15,8 @@ import { Controller } from "../../controller";
 export default class QuarterLayout implements WindowsLayout {
   public static readonly MAX_PROPORTION = 0.8;
   public static readonly id = "QuarterLayout";
-
   public readonly classID = QuarterLayout.id;
-  public readonly description = "Quarter";
+  public readonly name = "Quarter Layout";
 
   public get capacity(): number {
     return 4;

--- a/src/kwinscript/engine/layout/spiral_layout.ts
+++ b/src/kwinscript/engine/layout/spiral_layout.ts
@@ -19,7 +19,7 @@ export type SpiralLayoutPart = HalfSplitLayoutPart<
 >;
 
 export default class SpiralLayout implements WindowsLayout {
-  public readonly description = "Spiral";
+  public readonly name = "Spiral Layout";
 
   private depth: number;
   private parts: SpiralLayoutPart;

--- a/src/kwinscript/engine/layout/spiral_layout.ts
+++ b/src/kwinscript/engine/layout/spiral_layout.ts
@@ -20,6 +20,7 @@ export type SpiralLayoutPart = HalfSplitLayoutPart<
 
 export default class SpiralLayout implements WindowsLayout {
   public readonly name = "Spiral Layout";
+  public readonly icon = "bismuth-spiral";
 
   private depth: number;
   private parts: SpiralLayoutPart;

--- a/src/kwinscript/engine/layout/spread_layout.ts
+++ b/src/kwinscript/engine/layout/spread_layout.ts
@@ -19,9 +19,8 @@ import { Engine } from "..";
 
 export default class SpreadLayout implements WindowsLayout {
   public static readonly id = "SpreadLayout";
-
   public readonly classID = SpreadLayout.id;
-  public readonly description = "Spread";
+  public readonly name = "Spread Layout";
 
   private space: number; /* in ratio */
 

--- a/src/kwinscript/engine/layout/spread_layout.ts
+++ b/src/kwinscript/engine/layout/spread_layout.ts
@@ -21,6 +21,7 @@ export default class SpreadLayout implements WindowsLayout {
   public static readonly id = "SpreadLayout";
   public readonly classID = SpreadLayout.id;
   public readonly name = "Spread Layout";
+  public readonly icon = "bismuth-spread";
 
   private space: number; /* in ratio */
 

--- a/src/kwinscript/engine/layout/stair_layout.ts
+++ b/src/kwinscript/engine/layout/stair_layout.ts
@@ -21,6 +21,7 @@ export default class StairLayout implements WindowsLayout {
   public static readonly id = "StairLayout";
   public readonly classID = StairLayout.id;
   public readonly name = "Stair Layout";
+  public readonly icon = "bismuth-stair";
 
   private space: number; /* in PIXELS */
 

--- a/src/kwinscript/engine/layout/stair_layout.ts
+++ b/src/kwinscript/engine/layout/stair_layout.ts
@@ -19,9 +19,8 @@ import { Engine } from "..";
 
 export default class StairLayout implements WindowsLayout {
   public static readonly id = "StairLayout";
-
   public readonly classID = StairLayout.id;
-  public readonly description = "Stair";
+  public readonly name = "Stair Layout";
 
   private space: number; /* in PIXELS */
 

--- a/src/kwinscript/engine/layout/three_column_layout.ts
+++ b/src/kwinscript/engine/layout/three_column_layout.ts
@@ -26,11 +26,11 @@ export default class ThreeColumnLayout implements WindowsLayout {
   public static readonly MIN_MASTER_RATIO = 0.2;
   public static readonly MAX_MASTER_RATIO = 0.75;
   public static readonly id = "ThreeColumnLayout";
-
   public readonly classID = ThreeColumnLayout.id;
+  public readonly name = "Three-Column Layout";
 
-  public get description(): string {
-    return `Three-Column [${this.masterSize}]`;
+  public get hint(): string {
+    return String(this.masterSize);
   }
 
   private masterRatio: number;

--- a/src/kwinscript/engine/layout/three_column_layout.ts
+++ b/src/kwinscript/engine/layout/three_column_layout.ts
@@ -28,6 +28,7 @@ export default class ThreeColumnLayout implements WindowsLayout {
   public static readonly id = "ThreeColumnLayout";
   public readonly classID = ThreeColumnLayout.id;
   public readonly name = "Three-Column Layout";
+  public readonly icon = "bismuth-column";
 
   public get hint(): string {
     return String(this.masterSize);

--- a/src/kwinscript/engine/layout/tile_layout.ts
+++ b/src/kwinscript/engine/layout/tile_layout.ts
@@ -33,11 +33,11 @@ export default class TileLayout implements WindowsLayout {
   public static readonly MIN_MASTER_RATIO = 0.2;
   public static readonly MAX_MASTER_RATIO = 0.8;
   public static readonly id = "TileLayout";
-
   public readonly classID = TileLayout.id;
+  public readonly name = "Tile Layout";
 
-  public get description(): string {
-    return `Tile [${this.numMaster}]`;
+  public get hint(): string {
+    return String(this.numMaster);
   }
 
   private parts: RotateLayoutPart<

--- a/src/kwinscript/engine/layout/tile_layout.ts
+++ b/src/kwinscript/engine/layout/tile_layout.ts
@@ -35,6 +35,7 @@ export default class TileLayout implements WindowsLayout {
   public static readonly id = "TileLayout";
   public readonly classID = TileLayout.id;
   public readonly name = "Tile Layout";
+  public readonly icon = "bismuth-tile";
 
   public get hint(): string {
     return String(this.numMaster);

--- a/src/kwinscript/extern/global.d.ts
+++ b/src/kwinscript/extern/global.d.ts
@@ -23,7 +23,7 @@ declare namespace Bismuth {
     }
 
     export interface PopupDialog {
-      show(text: string, text2?: string, icon?: string): void;
+      show(text: string, icon?: string, hint?: string): void;
     }
   }
 }

--- a/src/kwinscript/extern/global.d.ts
+++ b/src/kwinscript/extern/global.d.ts
@@ -23,7 +23,7 @@ declare namespace Bismuth {
     }
 
     export interface PopupDialog {
-      show(text: string): void;
+      show(text: string, text2?: string, icon?: string): void;
     }
   }
 }

--- a/src/kwinscript/ui/main.qml
+++ b/src/kwinscript/ui/main.qml
@@ -43,8 +43,8 @@ Item {
     Loader {
         id: popupDialog
 
-        function show(text, text2, icon) {
-            this.item.show(text, text2, icon);
+        function show(text, icon, hint) {
+            this.item.show(text, icon, hint);
         }
 
         source: "popup.qml"

--- a/src/kwinscript/ui/main.qml
+++ b/src/kwinscript/ui/main.qml
@@ -43,8 +43,8 @@ Item {
     Loader {
         id: popupDialog
 
-        function show(text) {
-            this.item.show(text);
+        function show(text, text2, icon) {
+            this.item.show(text, text2, icon);
         }
 
         source: "popup.qml"

--- a/src/kwinscript/ui/popup.qml
+++ b/src/kwinscript/ui/popup.qml
@@ -22,17 +22,9 @@ PlasmaCore.Dialog {
         // Set the text
         messageLabel.text = text;
         // Set the hint text
-        if (typeof text2 !== 'undefined') {
-            messageLabel2.text = text2;
-        } else {
-            messageLabel2.text = "";
-        }
+        messageLabel2.text = text2 || ""; // Fallback to empty string when undefined
         // Set the icon
-        if (typeof icon !== 'undefined') {
-            messageIcon.source = icon;
-        } else {
-            messageIcon.source = "bismuth";
-        }
+        messageIcon.source = icon || "bismuth"; // Fallback icon when undefined
         this.visible = true;
         // Start popup hide timer
         hideTimer.interval = 3000;

--- a/src/kwinscript/ui/popup.qml
+++ b/src/kwinscript/ui/popup.qml
@@ -14,17 +14,16 @@ PlasmaCore.Dialog {
 
     property rect screenGeometry
 
-    function show(text, text2, icon) {
+    function show(text, icon, hint) {
         // Abort any previous timers
         hideTimer.stop();
         // Update current screen information
         this.screenGeometry = workspace.clientArea(KWin.FullScreenArea, workspace.activeScreen, workspace.currentDesktop);
-        // Set the text
-        messageLabel.text = text;
-        // Set the hint text
-        messageLabel2.text = text2 || ""; // Fallback to empty string when undefined
-        // Set the icon
-        messageIcon.source = icon || "bismuth"; // Fallback icon when undefined
+        // Set the icon and text
+        messageText.text = text;
+        messageIcon.source = icon || "bismuth"; // Fallback to the default icon when undefined
+        messageHint.text = hint || ""; // Fallback to the empty string when undefined
+        // Show the popup
         this.visible = true;
         // Start popup hide timer
         hideTimer.interval = 3000;
@@ -47,7 +46,7 @@ PlasmaCore.Dialog {
         id: main
 
         // Make popup size consistent with the other Plasma OSD (e.g. PulseAudio one)
-        Layout.minimumWidth: Math.max(messageLabel.implicitWidth, PlasmaCore.Units.gridUnit * 15)
+        Layout.minimumWidth: Math.max(messageText.implicitWidth, PlasmaCore.Units.gridUnit * 15)
         Layout.minimumHeight: PlasmaCore.Units.gridUnit * 1.35
 
         PlasmaCore.IconItem {
@@ -60,7 +59,7 @@ PlasmaCore.Dialog {
         }
 
         PC3.Label {
-            id: messageLabel
+            id: messageText
 
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
@@ -70,7 +69,7 @@ PlasmaCore.Dialog {
         }
 
         PC3.Label {
-            id: messageLabel2
+            id: messageHint
 
             Layout.rightMargin: PlasmaCore.Units.smallSpacing * 2
             Layout.alignment: Qt.AlignHCenter

--- a/src/kwinscript/ui/popup.qml
+++ b/src/kwinscript/ui/popup.qml
@@ -14,13 +14,25 @@ PlasmaCore.Dialog {
 
     property rect screenGeometry
 
-    function show(text) {
+    function show(text, text2, icon) {
         // Abort any previous timers
         hideTimer.stop();
         // Update current screen information
         this.screenGeometry = workspace.clientArea(KWin.FullScreenArea, workspace.activeScreen, workspace.currentDesktop);
-        // Set the text for the popup
+        // Set the text
         messageLabel.text = text;
+        // Set the hint text
+        if (typeof text2 !== 'undefined') {
+            messageLabel2.text = text2;
+        } else {
+            messageLabel2.text = "";
+        }
+        // Set the icon
+        if (typeof icon !== 'undefined') {
+            messageIcon.source = icon;
+        } else {
+            messageIcon.source = "bismuth";
+        }
         this.visible = true;
         // Start popup hide timer
         hideTimer.interval = 3000;
@@ -46,9 +58,29 @@ PlasmaCore.Dialog {
         Layout.minimumWidth: Math.max(messageLabel.implicitWidth, PlasmaCore.Units.gridUnit * 15)
         Layout.minimumHeight: PlasmaCore.Units.gridUnit * 1.35
 
+        PlasmaCore.IconItem {
+            id: messageIcon
+
+            Layout.leftMargin: PlasmaCore.Units.smallSpacing
+            Layout.preferredWidth: PlasmaCore.Units.iconSizes.medium
+            Layout.preferredHeight: PlasmaCore.Units.iconSizes.medium
+            Layout.alignment: Qt.AlignVCenter
+        }
+
         PC3.Label {
             id: messageLabel
 
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignHCenter
+            // This font size matches the one from Pulse Audio OSD for consistency
+            font.pointSize: PlasmaCore.Theme.defaultFont.pointSize * 1.2
+            horizontalAlignment: Text.AlignHCenter
+        }
+
+        PC3.Label {
+            id: messageLabel2
+
+            Layout.rightMargin: PlasmaCore.Units.smallSpacing * 2
             Layout.alignment: Qt.AlignHCenter
             // This font size matches the one from Pulse Audio OSD for consistency
             font.pointSize: PlasmaCore.Theme.defaultFont.pointSize * 1.2

--- a/src/kwinscript/ui/popup.qml
+++ b/src/kwinscript/ui/popup.qml
@@ -2,8 +2,7 @@
 // SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
 // SPDX-License-Identifier: MIT
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import org.kde.kwin 2.0
 import org.kde.plasma.components 3.0 as PC3
@@ -71,11 +70,21 @@ PlasmaCore.Dialog {
         PC3.Label {
             id: messageHint
 
+            Layout.preferredWidth: widestHintSize.width
             Layout.rightMargin: PlasmaCore.Units.smallSpacing * 2
             Layout.alignment: Qt.AlignHCenter
             // This font size matches the one from Pulse Audio OSD for consistency
             font.pointSize: PlasmaCore.Theme.defaultFont.pointSize * 1.2
             horizontalAlignment: Text.AlignHCenter
+        }
+
+        // Get the width of a two-digit number so we can size the hint
+        // to the maximum width to avoid the main text moving around
+        TextMetrics {
+          id: widestHintSize
+
+          text: i18n("10")
+          font: messageHint.font
         }
 
         // Hides the popup window when triggered


### PR DESCRIPTION
## Summary

Adds two optional parameters to the `showNotification` function:
- `icon` - name of the icon, which should be displayed in the popup.
- `hint` - right-aligned text, used to display the number of master windows in some layouts.

Required for #176.