### PR TITLE
chore: add depends clause to ui build rule

### DIFF
--- a/src/kwinscript/CMakeLists.txt
+++ b/src/kwinscript/CMakeLists.txt
@@ -50,6 +50,10 @@ add_custom_command(
   OUTPUT "bismuth/contents/ui"
   COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory"
   "${CMAKE_CURRENT_SOURCE_DIR}/ui" "${CMAKE_CURRENT_BINARY_DIR}/bismuth/contents/ui"
+  DEPENDS
+  "${CMAKE_CURRENT_SOURCE_DIR}/ui/main.qml"
+  "${CMAKE_CURRENT_SOURCE_DIR}/ui/TrayItem.qml"
+  "${CMAKE_CURRENT_SOURCE_DIR}/ui/popup.qml"
   COMMENT "📑 Preparing UI and metadata files..."
 )
 


### PR DESCRIPTION
This way the qml files would be automatically up to date
and would not require the rebuild.

