### PR TITLE
Add KDE Neon to the sysdep-install.sh

### DIFF
--- a/scripts/sysdep-install.sh
+++ b/scripts/sysdep-install.sh
@@ -12,7 +12,7 @@ if [ -f /etc/os-release ]; then
 
   case $ID in
 
-    "ubuntu" | "pop" | "debian")
+    "ubuntu" | "pop" | "debian" | "neon" )
       sudo apt-get install -y \
         cmake ninja-build extra-cmake-modules kirigami2-dev \
         libkf5config-dev libkf5configwidgets-dev libkf5coreaddons-dev \


### PR DESCRIPTION
I was trying to install this in KDE neon and the dependency installation script doesn't work. While I could manually run this, I think it would be easy for KDE Neon users to have it run directly like this. 

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Summary of the pull request.

## Breaking Changes

Do your changes intentionally break something on the user side or configuration?

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| Screenshot of UI before change | Screenshot of UI after change |

## Test Plan

1. Reload Script...
2. ...
3. Something happens

## Related Issues

Closes #X
