### PR TITLE
fix: properly maximize windows via window decoration buttons

### DIFF
--- a/src/kwinscript/engine/window.ts
+++ b/src/kwinscript/engine/window.ts
@@ -331,7 +331,11 @@ export class EngineWindowImpl implements EngineWindow {
     this.log.log(["Window#commit", { state: WindowState[state] }]);
     switch (state) {
       case WindowState.NativeMaximized:
-        this.window.commit(undefined, undefined, false);
+        this.window.commit(
+          this.window.surface.workingArea,
+          undefined,
+          undefined
+        );
         break;
 
       case WindowState.NativeFullscreen:


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Apparently pressing the maximize button doesn't actually force the
window into any specific geometry. This resulted in windows staying in their
tiled geometry while all other windows would be rearranged as if the
maximized window would be floating.

This fix makes the maximized window fill the entire working area.

## Test Plan

1. Install PR version of script
2. Open two or more windows
3. Maximize one of the windows (via titlebar button or `Alt + F3` menu)
4. Watch window take up the whole working area

## Related Issues

Closes #101 
