### PR TITLE
fix: focus lone window with move focus shortcut

### DIFF
--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -458,12 +458,12 @@ export class EngineImpl implements Engine {
   public focusDir(dir: Direction): void {
     const window = this.controller.currentWindow;
 
-    /* if no current window, select the first tile. */
+    /* if no current window, select the first window. */
     if (window === null) {
-      const tiles = this.windows.visibleTiledWindowsOn(
+      const tiles = this.windows.visibleWindowsOn(
         this.controller.currentSurface
       );
-      if (tiles.length > 1) {
+      if (tiles.length > 0) {
         this.controller.currentWindow = tiles[0];
       }
       return;


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Before, when no window was focused, focusing a window with keyboard
shortcuts would only work if there were two or more windows visible. It
would also only consider tiled windows at all.

Now, any window, floating or tiled, is considered when no window was
focused previously.

## Test Plan

1. Install PR version of script
2. Open a single (floating) window
3. Unfocus the single window (click somewhere outside the floating window)
4. Use any focus window shortcut (e.g. Focus Upper Window; default `Meta + j`)
5. Observe how the single visible window gets focus
