### PR TITLE
feat: allow moving focus to floating windows with keyboard shortcuts

### DIFF
--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -667,30 +667,34 @@ export class EngineImpl implements Engine {
         return candidates;
       }
 
-      // find windows that additionally overlap with the last focused window
+      // find windows that additionally overlap with the last focused tiled window
       // this will avoid switching sides of the screen when walking through floating windows
       // and should prevent getting locked out from certain windows in some layouts
       const lastFocusedWindow = this.windows
         .visibleWindowsOn(this.controller.currentSurface)
-        .sort((a, b) => b.timestamp - a.timestamp)[1];
+        .filter((window) => window.tiled)
+        .sort((a, b) => b.timestamp - a.timestamp)[0];
 
-      const narrowSelection = selection.filter((window): boolean => {
-        if (dir === "up" || dir === "down") {
-          return overlap(
-            lastFocusedWindow.actualGeometry.x,
-            lastFocusedWindow.actualGeometry.maxX,
-            window.actualGeometry.x,
-            window.actualGeometry.maxX
-          );
-        } else {
-          return overlap(
-            lastFocusedWindow.actualGeometry.y,
-            lastFocusedWindow.actualGeometry.maxY,
-            window.actualGeometry.y,
-            window.actualGeometry.maxY
-          );
-        }
-      });
+      let narrowSelection: EngineWindow[] = [];
+      if (lastFocusedWindow !== undefined) {
+        narrowSelection = selection.filter((window): boolean => {
+          if (dir === "up" || dir === "down") {
+            return overlap(
+              lastFocusedWindow.actualGeometry.x,
+              lastFocusedWindow.actualGeometry.maxX,
+              window.actualGeometry.x,
+              window.actualGeometry.maxX
+            );
+          } else {
+            return overlap(
+              lastFocusedWindow.actualGeometry.y,
+              lastFocusedWindow.actualGeometry.maxY,
+              window.actualGeometry.y,
+              window.actualGeometry.maxY
+            );
+          }
+        });
+      }
 
       if (narrowSelection.length !== 0) {
         selection = narrowSelection;

--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -628,36 +628,107 @@ export class EngineImpl implements Engine {
   private getNeighborCandidates(
     basis: EngineWindow,
     dir: Direction
-  ): EngineWindow[] {
-    const visibleWindowsOnCurrentSurface = this.windows.visibleTiledWindowsOn(
+  ): EngineWindow[] | null {
+    const visibleWindowsOnCurrentSurface = this.windows.visibleWindowsOn(
       this.controller.currentSurface
     );
 
     // Flipping all inputs' signs allows for the same logic to find closest windows in either direction
     const sign = dir === "down" || dir === "right" ? 1 : -1;
 
-    if (dir === "up" || dir === "down") {
-      return visibleWindowsOnCurrentSurface.filter(
-        (window): boolean =>
-          window.geometry.y * sign > basis.geometry.y * sign &&
-          overlap(
-            basis.geometry.x,
-            basis.geometry.maxX,
-            window.geometry.x,
-            window.geometry.maxX
-          )
-      );
+    const candidates = visibleWindowsOnCurrentSurface.filter(
+      (window): boolean => {
+        if (dir === "up" || dir === "down") {
+          return (
+            window.actualGeometry.center[1] * sign >
+            basis.actualGeometry.center[1] * sign
+          );
+        } else {
+          return (
+            window.actualGeometry.center[0] * sign >
+            basis.actualGeometry.center[0] * sign
+          );
+        }
+      }
+    );
+
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    let selection: EngineWindow[] = candidates.filter((window): boolean => {
+      // use smaller target area for floating windows to improve navigation around them
+      // 2: full window width/height
+      // 3: 2/3 of window size
+      const basisSizeFactor = basis.floating ? 3 : 2;
+      const windowSizeFactor = window.floating ? 3 : 2;
+      if (dir === "up" || dir === "down") {
+        return overlap(
+          basis.actualGeometry.center[0] -
+            Math.floor(basis.actualGeometry.width / basisSizeFactor),
+          basis.actualGeometry.center[0] +
+            Math.floor(basis.actualGeometry.width / basisSizeFactor),
+          window.actualGeometry.center[0] -
+            Math.floor(window.actualGeometry.width / windowSizeFactor),
+          window.actualGeometry.center[0] +
+            Math.floor(window.actualGeometry.width / windowSizeFactor)
+        );
+      } else {
+        return overlap(
+          basis.actualGeometry.center[1] -
+            Math.floor(basis.actualGeometry.height / basisSizeFactor),
+          basis.actualGeometry.center[1] +
+            Math.floor(basis.actualGeometry.height / basisSizeFactor),
+          window.actualGeometry.center[1] -
+            Math.floor(window.actualGeometry.height / windowSizeFactor),
+          window.actualGeometry.center[1] +
+            Math.floor(window.actualGeometry.height / windowSizeFactor)
+        );
+      }
+    });
+
+    if (selection.length === 0) {
+      if (basis.floating) {
+        // randomly floating windows, pick any candidate
+        selection = candidates;
+      } else {
+        return null;
+      }
+    } else if (selection.length > 1 && basis.floating) {
+      // find windows that additionally overlap with the last focused window
+      // this will avoid switching sides of the screen when walking through floating windows
+      // and should prevent getting locked out from certain windows in some layouts
+      const lastFocusedWindow = this.windows
+        .visibleWindowsOn(this.controller.currentSurface)
+        .sort((a, b) => b.timestamp - a.timestamp)[1];
+
+      const narrowSelection = selection.filter((window): boolean => {
+        if (dir === "up" || dir === "down") {
+          return overlap(
+            lastFocusedWindow.actualGeometry.x,
+            lastFocusedWindow.actualGeometry.maxX,
+            window.actualGeometry.x,
+            window.actualGeometry.maxX
+          );
+        } else {
+          return overlap(
+            lastFocusedWindow.actualGeometry.y,
+            lastFocusedWindow.actualGeometry.maxY,
+            window.actualGeometry.y,
+            window.actualGeometry.maxY
+          );
+        }
+      });
+
+      if (narrowSelection.length !== 0) {
+        selection = narrowSelection;
+      }
+    }
+
+    if (selection.length > 0) {
+      return selection;
     } else {
-      return visibleWindowsOnCurrentSurface.filter(
-        (window): boolean =>
-          window.geometry.x * sign > basis.geometry.x * sign &&
-          overlap(
-            basis.geometry.y,
-            basis.geometry.maxY,
-            window.geometry.y,
-            window.geometry.maxY
-          )
-      );
+      return null;
     }
   }
 
@@ -669,13 +740,13 @@ export class EngineImpl implements Engine {
       (prevValue, window): number => {
         switch (dir) {
           case "up":
-            return Math.max(window.geometry.maxY, prevValue);
+            return Math.max(window.actualGeometry.maxY, prevValue);
           case "down":
-            return Math.min(window.geometry.y, prevValue);
+            return Math.min(window.actualGeometry.y, prevValue);
           case "left":
-            return Math.max(window.geometry.maxX, prevValue);
+            return Math.max(window.actualGeometry.maxX, prevValue);
           case "right":
-            return Math.min(window.geometry.x, prevValue);
+            return Math.min(window.actualGeometry.x, prevValue);
         }
       },
       dir === "up" || dir === "left" ? 0 : Infinity
@@ -691,13 +762,13 @@ export class EngineImpl implements Engine {
       // adjust closestPoint for potential misalignment of tiled windows
       switch (dir) {
         case "up":
-          return window.geometry.maxY > closestPoint - 5;
+          return window.actualGeometry.maxY > closestPoint - 5;
         case "down":
-          return window.geometry.y < closestPoint + 5;
+          return window.actualGeometry.y < closestPoint + 5;
         case "left":
-          return window.geometry.maxX > closestPoint - 5;
+          return window.actualGeometry.maxX > closestPoint - 5;
         case "right":
-          return window.geometry.x < closestPoint + 5;
+          return window.actualGeometry.x < closestPoint + 5;
       }
     });
   }
@@ -708,7 +779,7 @@ export class EngineImpl implements Engine {
   ): EngineWindow | null {
     const neighborCandidates = this.getNeighborCandidates(basis, dir);
 
-    if (neighborCandidates.length === 0) {
+    if (neighborCandidates === null) {
       return null;
     }
 


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Before, switching focus with keyboard shortcuts was only possible
between tiled windows. Now one can also navigate to floating windows.

When finding candidates for focus switching, floating windows will be
treated as smaller than they really are. This means that floating
windows can overlap tiled windows slightly without automatically
becoming the first choice for focus switching. This improves navigation
around floating windows as switching behavior will feel more
predictable.

## Test Plan

1. Install PR version of script
2. Open a few windows
3. Make one window floating
4. Try to navigate to that window with only keyboard shortcuts


https://user-images.githubusercontent.com/72616153/143285123-1fec66c8-4220-409f-8870-7965ec428522.mp4

