### PR TITLE
chore: set the project version in the top cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,23 @@ option(
 set(QT_MIN_VERSION "5.15.0")
 set(KF5_MIN_VERSION "5.80.0")
 
+# HACK: Use git to get the recent version
+# We could explicitly set the version via project declaration
+# But this would conflict with package.json and would
+# Require automatic change via Release Please time CI
+execute_process(COMMAND "git" "describe" "--tags" "--abbrev=0" OUTPUT_VARIABLE CMAKE_PROJECT_VERSION)
+string(REPLACE "\n" "" CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION}")
+string(REPLACE "v" "" CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION}")
+
+# TODO: Less hacky solution, however it requires CMake 3.19
+# which is not so common across distros as of now.
+# Uncomment when cmake_minimum_required >= 3.19.
+#
+# # Set the project version
+# file(READ ${CMAKE_CURRENT_SOURCE_DIR}/package.json PACKAGE_JSON)
+# string(JSON CMAKE_PROJECT_VERSION GET ${PACKAGE_JSON} version)
+# unset(PACKAGE_JSON)
+
 find_package(ECM ${KF5_MIN_VERSION} REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 

--- a/src/kwinscript/CMakeLists.txt
+++ b/src/kwinscript/CMakeLists.txt
@@ -5,14 +5,6 @@ cmake_minimum_required(VERSION 3.16)
 
 project(bismuth-kwinscript)
 
-# HACK: Use git to get the recent version
-# We could explicitly set the version via project declaration
-# But this would conflict with package.json and would
-# Require automatic change via Release Please time CI
-execute_process(COMMAND "git" "describe" "--tags" "--abbrev=0" OUTPUT_VARIABLE CMAKE_PROJECT_VERSION)
-string(REPLACE "\n" "" CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION}")
-string(REPLACE "v" "" CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION}")
-
 add_custom_target(
   KWinScript ALL
   COMMENT "🏗️ Building KWin Script..."


### PR DESCRIPTION
## Summary

Moves the code used for determining project version to the root CMakeList file. That's because `CMAKE_PROJECT_VERSION` variable will be required for the applet as well. 