### PR TITLE
Expose a DBus service with methods, that can be called by external programs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 include(KDEInstallDirs)
 include(KDECMakeSettings)
 include(KDECompilerSettings NO_POLICY_SCOPE)
-
+include(KDEClangFormat)
 include(ECMInstallIcons)
 
 find_package(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
 # SPDX-License-Identifier: MIT
 
+add_subdirectory(dbus-plugin)
 add_subdirectory(kcm)
 add_subdirectory(kwinscript)

--- a/src/dbus-plugin/CMakeLists.txt
+++ b/src/dbus-plugin/CMakeLists.txt
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+# SPDX-License-Identifier: MIT
+
+project(bismuth-dbus-plugin)
+
+add_library(dbus_bismuth_plugin SHARED)
+
+qt_generate_dbus_interface(
+  dbus-service.h
+  org.kde.bismuth.dbus.xml
+  OPTIONS -m
+)
+
+target_sources(
+  dbus_bismuth_plugin
+  PRIVATE
+  dbus-service.cpp
+  dbus-plugin.cpp
+  imports/qmldir
+  "${CMAKE_CURRENT_BINARY_DIR}/org.kde.bismuth.dbus.xml"
+)
+
+target_link_libraries(
+  dbus_bismuth_plugin
+  PRIVATE
+  Qt5::Core
+  Qt5::Quick
+  Qt5::Qml
+  Qt5::DBus
+)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/org.kde.bismuth.dbus.xml"
+  DESTINATION "${DBUS_INTERFACES_INSTALL_DIR}"
+)
+
+install(
+  TARGETS dbus_bismuth_plugin
+  DESTINATION "${KDE_INSTALL_QMLDIR}/org/kde/bismuth/dbus"
+)
+
+install(
+  DIRECTORY imports/ # Slash is important
+  DESTINATION "${KDE_INSTALL_QMLDIR}/org/kde/bismuth/dbus"
+)

--- a/src/dbus-plugin/dbus-plugin.cpp
+++ b/src/dbus-plugin/dbus-plugin.cpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#include "dbus-plugin.h"
+
+#include "dbus-service.h"
+
+void DBusPlugin::registerTypes(const char *uri)
+{
+    Q_ASSERT(uri == QLatin1String("org.kde.bismuth.dbus"));
+    qmlRegisterModule(uri, 1, 0);
+
+    qmlRegisterType<DBusService>(uri, 1, 0, "DBusService");
+}

--- a/src/dbus-plugin/dbus-plugin.h
+++ b/src/dbus-plugin/dbus-plugin.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QQmlExtensionPlugin>
+
+class DBusPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID QQmlEngineExtensionInterface_iid)
+
+public:
+    void registerTypes(const char *uri) override;
+};

--- a/src/dbus-plugin/dbus-service.cpp
+++ b/src/dbus-plugin/dbus-service.cpp
@@ -28,6 +28,10 @@ DBusService::~DBusService()
     bus.unregisterObject("/bismuth");
 }
 
+EXTERNAL_REQUEST_MAPPER(bool, toggleLayoutOn, (const QString &layoutId, int screen, int desktop, const QString &activity), { //
+    return QJSValueList{layoutId, screen, desktop, activity};
+})
+
 EXTERNAL_REQUEST_MAPPER(QStringList, enabledLayouts, (), { //
     return QJSValueList{};
 })

--- a/src/dbus-plugin/dbus-service.cpp
+++ b/src/dbus-plugin/dbus-service.cpp
@@ -32,6 +32,6 @@ EXTERNAL_REQUEST_MAPPER(QStringList, enabledLayouts, (), { //
     return QJSValueList{};
 })
 
-// EXTERNAL_REQUEST_MAPPER(QString, activeLayout, (), { //
-//     return QJSValueList{};
-// })
+EXTERNAL_REQUEST_MAPPER(QString, layoutOn, (int screen, int desktop, const QString &activity), { //
+    return QJSValueList{screen, desktop, activity};
+})

--- a/src/dbus-plugin/dbus-service.cpp
+++ b/src/dbus-plugin/dbus-service.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#include "dbus-service.h"
+
+#include <QDBusConnection>
+#include <QDebug>
+
+DBusService::DBusService(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+    auto bus = QDBusConnection::sessionBus();
+    auto result = bus.registerService("org.kde.bismuth.dbus");
+    if (!result) {
+        qDebug() << "[Bismuth] [DBus Plugin] Cannot register DBus service with the name \"org.kde.bismuth.dbus\"";
+    }
+
+    result = bus.registerObject("/bismuth", this, QDBusConnection::ExportScriptableSlots);
+    if (!result) {
+        qDebug() << "[Bismuth] [DBus Plugin] Cannot register DBus object with path \"/bismuth\"";
+    }
+}
+
+DBusService::~DBusService()
+{
+    auto bus = QDBusConnection::sessionBus();
+    bus.unregisterService("org.kde.bismuth.dbus");
+    bus.unregisterObject("/bismuth");
+}
+
+EXTERNAL_REQUEST_MAPPER(QStringList, enabledLayouts, (), { //
+    return QJSValueList{};
+})
+
+// EXTERNAL_REQUEST_MAPPER(QString, activeLayout, (), { //
+//     return QJSValueList{};
+// })

--- a/src/dbus-plugin/dbus-service.h
+++ b/src/dbus-plugin/dbus-service.h
@@ -14,7 +14,7 @@ class DBusService : public QQuickItem
     QML_ELEMENT
 
     EXTERNAL_REQUEST(QStringList, enabledLayouts, ())
-    // EXTERNAL_REQUEST(QString, activeLayout, ())
+    EXTERNAL_REQUEST(QString, layoutOn, (int screen, int desktop, const QString &activity))
 
 public:
     DBusService(QQuickItem *parent = nullptr);

--- a/src/dbus-plugin/dbus-service.h
+++ b/src/dbus-plugin/dbus-service.h
@@ -13,6 +13,7 @@ class DBusService : public QQuickItem
     Q_CLASSINFO("D-Bus Interface", "org.kde.bismuth.dbus")
     QML_ELEMENT
 
+    EXTERNAL_REQUEST(bool, toggleLayoutOn, (const QString &layoutId, int screen, int desktop, const QString &activity))
     EXTERNAL_REQUEST(QStringList, enabledLayouts, ())
     EXTERNAL_REQUEST(QString, layoutOn, (int screen, int desktop, const QString &activity))
 

--- a/src/dbus-plugin/dbus-service.h
+++ b/src/dbus-plugin/dbus-service.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QString>
+
+#include "macro.h"
+
+class DBusService : public QQuickItem
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.kde.bismuth.dbus")
+    QML_ELEMENT
+
+    EXTERNAL_REQUEST(QStringList, enabledLayouts, ())
+    // EXTERNAL_REQUEST(QString, activeLayout, ())
+
+public:
+    DBusService(QQuickItem *parent = nullptr);
+    ~DBusService();
+
+Q_SIGNALS:
+    void layoutChangeRequested(const QString &layoutId);
+};

--- a/src/dbus-plugin/imports/qmldir
+++ b/src/dbus-plugin/imports/qmldir
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+# SPDX-License-Identifier: MIT
+
+module org.kde.bismuth.dbus
+
+# Plugin name is the name of the library in the CMakeLists.txt
+plugin dbus_bismuth_plugin
+classname DBusPlugin

--- a/src/dbus-plugin/macro.h
+++ b/src/dbus-plugin/macro.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+// Future reader, please forgive me for what I am about to do.
+
+#include <QDebug>
+#include <QJSValue>
+#include <QObject>
+
+/**
+ * Create a request that can be called externally via DBus method. Must be defined in the private part of the class.
+ * @param RETURN_TYPE return type of the request. Must be a type, that converts to the DBus types and not void.
+ * @param REQUEST_NAME name of the request
+ * @param INPUT_PARAMS Input parameters of the request in the form of function signature.
+ *        Must contain only the types, that could be converted to the DBus types.
+ */
+#define EXTERNAL_REQUEST(RETURN_TYPE, REQUEST_NAME, INPUT_PARAMS)                                                                                              \
+    Q_PROPERTY(QJSValue REQUEST_NAME##_handler READ REQUEST_NAME##_handler WRITE set##REQUEST_NAME##_handler);                                                 \
+                                                                                                                                                               \
+    QJSValue m_##REQUEST_NAME##_handler;                                                                                                                       \
+                                                                                                                                                               \
+public:                                                                                                                                                        \
+    QJSValue REQUEST_NAME##_handler() const                                                                                                                    \
+    {                                                                                                                                                          \
+        return m_##REQUEST_NAME##_handler;                                                                                                                     \
+    }                                                                                                                                                          \
+    void set##REQUEST_NAME##_handler(const QJSValue &handler)                                                                                                  \
+    {                                                                                                                                                          \
+        if (!handler.isCallable()) {                                                                                                                           \
+            qDebug() << "[Bismuth] [DBus Plugin] Cannot assign a handler to" << #REQUEST_NAME << "as it's not callable!";                                      \
+            return;                                                                                                                                            \
+        }                                                                                                                                                      \
+        m_##REQUEST_NAME##_handler = handler;                                                                                                                  \
+    }                                                                                                                                                          \
+                                                                                                                                                               \
+public Q_SLOTS:                                                                                                                                                \
+    Q_SCRIPTABLE RETURN_TYPE REQUEST_NAME INPUT_PARAMS;                                                                                                        \
+                                                                                                                                                               \
+private:
+
+/**
+ * Maps the arguments of an EXTERNAL_REQUEST with the provided signature to the QJSValueList
+ * @param ... Body of a lambda, that maps args of a DBus call to the QJSValueList for JS handler call
+ */
+#define EXTERNAL_REQUEST_MAPPER(RETURN_TYPE, REQUEST_NAME, INPUT_PARAMS, ...)                                                                                  \
+    RETURN_TYPE DBusService::REQUEST_NAME INPUT_PARAMS                                                                                                         \
+    {                                                                                                                                                          \
+        if (m_##REQUEST_NAME##_handler.isCallable()) {                                                                                                         \
+            auto args = [&]() -> QJSValueList {                                                                                                                \
+                __VA_ARGS__                                                                                                                                    \
+            }();                                                                                                                                               \
+                                                                                                                                                               \
+            auto result = m_##REQUEST_NAME##_handler.call(args);                                                                                               \
+            return result.toVariant().value<RETURN_TYPE>();                                                                                                    \
+        } else {                                                                                                                                               \
+            qDebug() << "[Bismuth] [DBus Plugin] Cannot call handler for" << #REQUEST_NAME << "as it's not callable!";                                         \
+            return {};                                                                                                                                         \
+        }                                                                                                                                                      \
+    }

--- a/src/kwinscript/controller/action.test.ts
+++ b/src/kwinscript/controller/action.test.ts
@@ -355,7 +355,7 @@ describe("action", () => {
 
       fakeEngine = createMock<Engine>({
         cycleLayout: jest.fn(),
-        toggleLayout: jest.fn(),
+        toggleLayoutOnCurrentSurface: jest.fn(),
         currentWindow: jest.fn().mockReturnValue(fakeCurrentWindow),
       });
     });
@@ -386,7 +386,9 @@ describe("action", () => {
 
         action.execute();
 
-        expect(fakeEngine.toggleLayout).toBeCalledWith("MonocleLayout");
+        expect(fakeEngine.toggleLayoutOnCurrentSurface).toBeCalledWith(
+          "MonocleLayout"
+        );
       });
     });
   });

--- a/src/kwinscript/controller/action.ts
+++ b/src/kwinscript/controller/action.ts
@@ -465,7 +465,7 @@ abstract class ToggleCurrentLayout extends ActionImpl implements Action {
   }
 
   public executeWithoutLayoutOverride(): void {
-    this.engine.toggleLayout(this.layoutId);
+    this.engine.toggleLayoutOnCurrentSurface(this.layoutId);
   }
 }
 

--- a/src/kwinscript/controller/action.ts
+++ b/src/kwinscript/controller/action.ts
@@ -7,7 +7,7 @@ import { Engine } from "../engine";
 import { Log } from "../util/log";
 
 /**
- * Action that is requested by the user.
+ * Action that is triggered with the keyboard shortcut
  */
 export interface Action {
   /**

--- a/src/kwinscript/controller/action.ts
+++ b/src/kwinscript/controller/action.ts
@@ -536,10 +536,9 @@ export class ToggleStairLayout extends ToggleCurrentLayout {
 
 export class ToggleFloatingLayout extends ToggleCurrentLayout {
   constructor(protected engine: Engine, protected log: Log) {
-    // NOTE: space is intentional (Temporary)
     super(
       engine,
-      "FloatingLayout ",
+      "FloatingLayout",
       "toggle_float_layout",
       "Toggle Floating Layout",
       "Meta+Shift+F",

--- a/src/kwinscript/controller/index.ts
+++ b/src/kwinscript/controller/index.ts
@@ -153,6 +153,15 @@ export interface Controller {
    * In particular, it's called by QML Component.onDestroyed
    */
   drop(): void;
+
+  /**
+   * Return the surface matching the parameters. If none is found, null is returned
+   */
+  surfaceOn(
+    screen: number,
+    desktop: number,
+    activity: string
+  ): DriverSurface | null;
 }
 
 export class ControllerImpl implements Controller {
@@ -387,6 +396,22 @@ export class ControllerImpl implements Controller {
     this.driver.drop();
   }
 
+  public surfaceOn(
+    screen: number,
+    desktop: number,
+    activity: string
+  ): DriverSurface | null {
+    if (screen < 0 || desktop < 1) {
+      return null;
+    }
+
+    if (activity === "") {
+      activity = this.driver.currentActivity;
+    }
+
+    return this.driver.surfaceOn(screen, desktop, activity);
+  }
+
   private bindTrayActions(): void {
     // NOTE: Since the qml interface is very agile, it's seems
     // to be unreasonable to make the bindings universal.
@@ -450,6 +475,7 @@ export class ControllerImpl implements Controller {
   private registerExternalRequests(): void {
     const allPossibleRequests = [
       new Request.EnabledLayouts(this.engine, this.log),
+      new Request.LayoutOn(this.engine, this.log),
     ];
 
     for (const request of allPossibleRequests) {

--- a/src/kwinscript/controller/index.ts
+++ b/src/kwinscript/controller/index.ts
@@ -14,6 +14,7 @@ import { Config } from "../config";
 import { Log } from "../util/log";
 
 import * as Action from "./action";
+import * as Request from "./request";
 
 /**
  * Entry point of the script (apart from QML). Handles the user input (shortcuts)
@@ -160,7 +161,7 @@ export class ControllerImpl implements Controller {
   public constructor(
     private qmlObjects: Bismuth.Qml.Main,
     kwinApi: KWin.Api,
-    private config: Config,
+    config: Config,
     private log: Log
   ) {
     this.engine = new EngineImpl(this, config, log);
@@ -176,6 +177,7 @@ export class ControllerImpl implements Controller {
     this.driver.bindEvents();
     this.bindTrayActions();
     this.bindShortcuts();
+    this.registerExternalRequests();
 
     this.driver.manageWindows();
 
@@ -442,6 +444,16 @@ export class ControllerImpl implements Controller {
 
     for (const action of allPossibleActions) {
       this.driver.bindShortcut(action);
+    }
+  }
+
+  private registerExternalRequests(): void {
+    const allPossibleRequests = [
+      new Request.EnabledLayouts(this.engine, this.log),
+    ];
+
+    for (const request of allPossibleRequests) {
+      this.driver.bindExternalRequest(request);
     }
   }
 }

--- a/src/kwinscript/controller/request.ts
+++ b/src/kwinscript/controller/request.ts
@@ -5,7 +5,7 @@
 import { Engine } from "../engine";
 import { Log } from "../util/log";
 
-export type ResponseType = string | string[];
+export type ResponseType = string | string[] | boolean;
 export type DBusArg = boolean | number | string | string[];
 
 /**
@@ -57,5 +57,19 @@ export class LayoutOn extends RequestImpl {
     const desktop = args[1] as number;
     const activity = args[2] as string;
     return this.engine.layoutOn(screen, desktop, activity);
+  }
+}
+
+export class ToggleTilingOn extends RequestImpl {
+  constructor(engine: Engine, log: Log) {
+    super("toggleLayoutOn", engine, log);
+  }
+
+  public execute(...args: DBusArg[]): boolean {
+    const layoutId = args[0] as string;
+    const screen = args[1] as number;
+    const desktop = args[2] as number;
+    const activity = args[3] as string;
+    return this.engine.toggleLayoutOn(layoutId, screen, desktop, activity);
   }
 }

--- a/src/kwinscript/controller/request.ts
+++ b/src/kwinscript/controller/request.ts
@@ -23,7 +23,7 @@ export interface Request {
   /**
    * Executes the request and returns the appropriate response.
    */
-  execute(args: DBusArg[]): ResponseType;
+  execute(...args: DBusArg[]): ResponseType;
 }
 
 abstract class RequestImpl implements Request {
@@ -33,7 +33,7 @@ abstract class RequestImpl implements Request {
     protected log: Log
   ) {}
 
-  abstract execute(args: DBusArg[]): ResponseType;
+  abstract execute(...args: DBusArg[]): ResponseType;
 }
 
 export class EnabledLayouts extends RequestImpl {
@@ -44,5 +44,18 @@ export class EnabledLayouts extends RequestImpl {
   public execute(): string[] {
     const enabledLayouts = this.engine.enabledLayouts();
     return enabledLayouts;
+  }
+}
+
+export class LayoutOn extends RequestImpl {
+  constructor(engine: Engine, log: Log) {
+    super("layoutOn", engine, log);
+  }
+
+  public execute(...args: DBusArg[]): string {
+    const screen = args[0] as number;
+    const desktop = args[1] as number;
+    const activity = args[2] as string;
+    return this.engine.layoutOn(screen, desktop, activity);
   }
 }

--- a/src/kwinscript/controller/request.ts
+++ b/src/kwinscript/controller/request.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+//
+// SPDX-License-Identifier: MIT
+
+import { Engine } from "../engine";
+import { Log } from "../util/log";
+
+export type ResponseType = string | string[];
+export type DBusArg = boolean | number | string | string[];
+
+/**
+ * DBus request from the external source
+ */
+export interface Request {
+  /*
+   * DBus method name.
+   *
+   * This must be the name of the request method in the DBus service.
+   * (Can be found in src/dbus-plugin/dbus-plugin.h)
+   */
+  readonly dbusName: string;
+
+  /**
+   * Executes the request and returns the appropriate response.
+   */
+  execute(args: DBusArg[]): ResponseType;
+}
+
+abstract class RequestImpl implements Request {
+  constructor(
+    public dbusName: string,
+    protected engine: Engine,
+    protected log: Log
+  ) {}
+
+  abstract execute(args: DBusArg[]): ResponseType;
+}
+
+export class EnabledLayouts extends RequestImpl {
+  constructor(engine: Engine, log: Log) {
+    super("enabledLayouts", engine, log);
+  }
+
+  public execute(): string[] {
+    const enabledLayouts = this.engine.enabledLayouts();
+    return enabledLayouts;
+  }
+}

--- a/src/kwinscript/driver/index.ts
+++ b/src/kwinscript/driver/index.ts
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2018-2019 Eon S. Jeon <esjeon@hyunmu.am>
-// SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-FileCopyrightText: 2021-2022 Mikhail Zolotukhin <mail@genda.life>
 //
 // SPDX-License-Identifier: MIT
 
@@ -27,6 +27,11 @@ export interface Driver {
    * All the surfaces/screens currently possess by the KWin
    */
   readonly screens: DriverSurface[];
+
+  /**
+   * Current user activity
+   */
+  readonly currentActivity: string;
 
   /**
    * Surface (screen) of the current window
@@ -72,6 +77,16 @@ export interface Driver {
    * Destroy all callbacks and other non-GC resources
    */
   drop(): void;
+
+  /**
+   * Get the surface mathing the parameters. If no surface is found,
+   * null is returened.
+   */
+  surfaceOn(
+    screen: number,
+    desktop: number,
+    activity: string
+  ): DriverSurface | null;
 }
 
 export class DriverImpl implements Driver {
@@ -98,6 +113,10 @@ export class DriverImpl implements Driver {
     if (this.kwinApi.workspace.currentDesktop !== kwinSurface.desktop) {
       this.kwinApi.workspace.currentDesktop = kwinSurface.desktop;
     }
+  }
+
+  public get currentActivity(): string {
+    return this.kwinApi.workspace.currentActivity;
   }
 
   public get currentWindow(): EngineWindow | null {
@@ -467,6 +486,21 @@ export class DriverImpl implements Driver {
     this.connect(client.shadeChanged, () => {
       this.controller.onWindowShadeChanged(window);
     });
+  }
+
+  public surfaceOn(
+    screen: number,
+    desktop: number,
+    activity: string
+  ): DriverSurface | null {
+    return new DriverSurfaceImpl(
+      screen,
+      activity,
+      desktop,
+      this.qml.activityInfo,
+      this.kwinApi,
+      this.config
+    );
   }
 }
 

--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -177,6 +177,11 @@ export interface Engine {
    * Return the list of currently enabled layouts
    */
   enabledLayouts(): string[];
+
+  /**
+   * Return the laouut on a surface specified by the parameters
+   */
+  layoutOn(screen: number, desktop: number, activity: string): string;
 }
 
 export class EngineImpl implements Engine {
@@ -750,6 +755,22 @@ export class EngineImpl implements Engine {
     return this.config.layoutOrder
       .filter((i) => i)
       .map((i) => i.replace("Layout", "").trim());
+  }
+
+  public layoutOn(screen: number, desktop: number, activity: string): string {
+    const matchingSurface = this.controller.surfaceOn(
+      screen,
+      desktop,
+      activity
+    );
+
+    if (matchingSurface == null) {
+      return "";
+    }
+
+    const layoutOnSurface = this.layouts.getCurrentLayout(matchingSurface);
+
+    return layoutOnSurface.name;
   }
 
   /**

--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -172,6 +172,11 @@ export interface Engine {
    * about the current layout.
    */
   showLayoutNotification(): void;
+
+  /**
+   * Return the list of currently enabled layouts
+   */
+  enabledLayouts(): string[];
 }
 
 export class EngineImpl implements Engine {
@@ -738,6 +743,13 @@ export class EngineImpl implements Engine {
       currentLayout.icon,
       currentLayout.hint
     );
+  }
+
+  public enabledLayouts(): string[] {
+    // Remove empty entries and remove the Layout word
+    return this.config.layoutOrder
+      .filter((i) => i)
+      .map((i) => i.replace("Layout", "").trim());
   }
 
   /**

--- a/src/kwinscript/engine/layout/floating_layout.ts
+++ b/src/kwinscript/engine/layout/floating_layout.ts
@@ -11,7 +11,7 @@ import { Rect } from "../../util/rect";
 import { Controller } from "../../controller";
 
 export default class FloatingLayout implements WindowsLayout {
-  public static readonly id = "FloatingLayout ";
+  public static readonly id = "FloatingLayout";
   public static instance = new FloatingLayout();
   public readonly classID = FloatingLayout.id;
   public readonly name = "Floating Layout";

--- a/src/kwinscript/engine/layout_store.ts
+++ b/src/kwinscript/engine/layout_store.ts
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import MonocleLayout from "./layout/monocle_layout";
 import FloatingLayout from "./layout/floating_layout";
 
 import { WindowsLayout } from "./layout";

--- a/src/kwinscript/extern/global.d.ts
+++ b/src/kwinscript/extern/global.d.ts
@@ -11,6 +11,7 @@ declare namespace Bismuth {
       scriptRoot: object;
       trayItem: TrayItem;
       activityInfo: Plasma.TaskManager.ActivityInfo;
+      dbusService: DBusService;
       popupDialog: PopupDialog;
     }
 
@@ -20,6 +21,11 @@ declare namespace Bismuth {
 
     export interface TrayMenu {
       onToggleTiling: () => void;
+    }
+
+    export interface DBusService {
+      // Request handlers, where the key is "${requestName}_handler"
+      [key: string]: (...args: any[]) => any;
     }
 
     export interface PopupDialog {

--- a/src/kwinscript/ui/main.qml
+++ b/src/kwinscript/ui/main.qml
@@ -4,6 +4,7 @@
 
 import "../code/index.mjs" as Bismuth
 import QtQuick 2.0
+import org.kde.bismuth.dbus 1.0 as BID
 import org.kde.kwin 2.0
 import org.kde.taskmanager 0.1 as TaskManager
 
@@ -18,6 +19,7 @@ Item {
             "scriptRoot": scriptRoot,
             "trayItem": trayItem,
             "activityInfo": activityInfo,
+            "dbusService": dbusService,
             "popupDialog": popupDialog
         };
         const kwinScriptingAPI = {
@@ -30,6 +32,14 @@ Item {
     Component.onDestruction: {
         console.log("[Bismuth] Everybody is dead");
         scriptRoot.controller.drop();
+    }
+
+    /**
+     * You can view all available handlers in:
+     * src/dbus-plugin/dbus-service.h
+     */
+    BID.DBusService {
+        id: dbusService
     }
 
     TrayItem {


### PR DESCRIPTION
## Summary

This exposes a DBus service, that can be used by external programs (e.g. a Plasma Applet). 

## Test Plan

1. Make sure, that the script is active adn up to date, if unsure, reload KWin.
2. Open QDbus Viewer and observe the exposed methods (see screenshot)
3. Try to call them with different arguments (via double-clicking)

![Screenshot_20211203_173539](https://user-images.githubusercontent.com/14205339/144620211-cddc1e21-0614-47d7-8ad3-691b51c77df9.png)

## Related Issues

Ref #23 
