### PR TITLE
fix: use correct min/max func and start val for finding closest window

### DIFF
--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -665,18 +665,21 @@ export class EngineImpl implements Engine {
     windowArray: EngineWindow[],
     dir: Direction
   ): number {
-    return windowArray.reduce((prevValue, window): number => {
-      switch (dir) {
-        case "up":
-          return Math.min(window.geometry.maxY, prevValue);
-        case "down":
-          return Math.max(window.geometry.y, prevValue);
-        case "left":
-          return Math.min(window.geometry.maxX, prevValue);
-        case "right":
-          return Math.max(window.geometry.x, prevValue);
-      }
-    }, Infinity);
+    return windowArray.reduce(
+      (prevValue, window): number => {
+        switch (dir) {
+          case "up":
+            return Math.max(window.geometry.maxY, prevValue);
+          case "down":
+            return Math.min(window.geometry.y, prevValue);
+          case "left":
+            return Math.max(window.geometry.maxX, prevValue);
+          case "right":
+            return Math.min(window.geometry.x, prevValue);
+        }
+      },
+      dir === "up" || dir === "left" ? 0 : Infinity
+    );
   }
 
   private getClosestRelativeWindow(


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

When doing the refactoring for #209, I seem to have mixed up some of the logic that wasn't caught during testing. Fixed it here.

When moving up, the closest window should be the lowest of all candidates and thus have the greatest y-coordinate. (The coordinate 0,0 is in the top-left corner and greater y-coordinates mean the window is further *down*.) Therefore it is necessary to use the `max()` function in this case instead of `min()`. In this case the starting value cannot be `Infinity` as that would always be the greatest value and not provide any useful result.

## Related issues

*Maybe* #221. I can't reproduce that issue either and actually found this regression independently while working on #210.
