### PR TITLE
Add fedora package

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ AUR helper.
 
 Updated ebuilds provided in [viperML-overlay](https://github.com/viperML/viperML-overlay/).
 
+#### Fedora
+
+Bismuth is available on the [Copr](https://copr.fedorainfracloud.org/coprs/capucho/bismuth)
+
 #### Other distributions
 
 If you are know a packaging solution for a distibution, that is not in this


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

I'm currently maintaining a rpm build of bismuth for my personal use, so I decided to polish it a little and publish it on the Copr. This is my first time packaging in fedora and rpm so it might not be ideal but it works fine for me in fedora 35.

I took the build dependencies from `scripts/sysdep-install.sh`.

The SPEC file is hosted on my github https://github.com/JCapucho/fedora-rpms

Link to the copr https://copr.fedorainfracloud.org/coprs/capucho/bismuth/