### PR TITLE
Add Debian/Ubuntu package

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ Updated ebuilds provided in [viperML-overlay](https://github.com/viperML/viperML
 
 #### Fedora
 
-Bismuth is available on the [Copr](https://copr.fedorainfracloud.org/coprs/capucho/bismuth)
+Bismuth is available on the [Copr](https://copr.fedorainfracloud.org/coprs/capucho/bismuth).
+
+#### Debian/Ubuntu
+
+Bismuth is available in the [Volian Repo](https://volian.org/bismuth/).
 
 #### Other distributions
 


### PR DESCRIPTION
Also added a period after the Fedora Copr for uniformity

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Add Debian/Ubuntu package

This will work on the following releases.

Debian stable/bullseye
Debian testing/bookworm
Debian unstable/sid

Ubuntu 21.04+

Unfortunately it seems maybe plasma is too old for Ubuntu 20.04.
