### PR TITLE
Float more utility windows in wayland

### DIFF
--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -129,7 +129,7 @@ export class DriverWindowImpl implements DriverWindow {
       this.client.modal ||
       !this.client.resizeable ||
       (this.config.floatUtility &&
-        (this.client.dialog || this.client.splash || this.client.utility)) ||
+        (this.client.dialog || this.client.splash || this.client.utility || this.client.transient)) ||
       this.config.floatingClass.indexOf(resourceClass) >= 0 ||
       this.config.floatingClass.indexOf(resourceName) >= 0 ||
       matchWords(this.client.caption, this.config.floatingTitle) >= 0


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Some utility windows are reported as transient windows from the master windows. Other class might never be reported


## Breaking 

None

## Test Plan

1. Reload Script on wayland
2. More utility windows should be floating instead of being tiled. Not all of them though

## Related Issues

Partially close #115 
