### PR TITLE
fix: quarter layout keyboard shortcut

### DIFF
--- a/src/kcm/bismuth_config.kcfg
+++ b/src/kcm/bismuth_config.kcfg
@@ -47,7 +47,7 @@
 
     <entry name="enableQuarterLayout" type="Bool">
 	    <label>Enable/disable Quarter layout</label>
-      <default>false</default>
+      <default>true</default>
     </entry>
 
     <entry name="enableFloatingLayout" type="Bool">


### PR DESCRIPTION
With reference to the last commit, just realized Quarter Layout keyboard shortcut wasn't working too 😅