### PR TITLE
fix typo: "TypeScirpt"

### DIFF
--- a/src/kwinscript/CMakeLists.txt
+++ b/src/kwinscript/CMakeLists.txt
@@ -57,7 +57,7 @@ add_custom_command(
   COMMAND ${TSC_COMMAND}
   COMMAND ${ESBUILD_COMMAND}
   COMMAND DEPENDS ${TYPESCRIPT_SOURCES}
-  COMMENT "🏗️ Compiling and bundling TypeScirpt sources..."
+  COMMENT "🏗️ Compiling and bundling TypeScript sources..."
 )
 
 add_custom_command(


### PR DESCRIPTION
Fixes the following message:
> 🏗️ Compiling and bundling **TypeScirpt** sources...

Untested since I'm new to Bismuth, and it's only a comment. I hope this doesn't annoy you too much. :)