### PR TITLE
Add Solus to distributions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ contact the package maintainer first.
 
 - [VipreML Overlay](https://github.com/viperML/viperML-overlay/)
 
+#### Solus
+
+- [Solus](https://dev.getsol.us/source/bismuth)
+
 #### From Source
 
 - [See Dev Docs](CONTRIBUTING.md)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary
Adds Solus to the list of distros in README.md.

Package: https://dev.getsol.us/source/bismuth

I can't decide what is best to use as the link text because, unlike all the other distributions, the package is in the official repo (which is just called 'Solus' in eopkg, the package manager).