### PR TITLE
Make most of utility windows float on wayland

### DIFF
--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -130,9 +130,9 @@ export class DriverWindowImpl implements DriverWindow {
       !this.client.resizeable ||
       (this.config.floatUtility &&
         (this.client.dialog ||
-         this.client.splash ||
-         this.client.utility ||
-         this.client.transient)) ||
+          this.client.splash ||
+          this.client.utility ||
+          this.client.transient)) ||
       this.config.floatingClass.indexOf(resourceClass) >= 0 ||
       this.config.floatingClass.indexOf(resourceName) >= 0 ||
       matchWords(this.client.caption, this.config.floatingTitle) >= 0

--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -129,7 +129,7 @@ export class DriverWindowImpl implements DriverWindow {
       this.client.modal ||
       !this.client.resizeable ||
       (this.config.floatUtility &&
-        (this.client.dialog || this.client.splash || this.client.utility)) ||
+        (this.client.dialog || this.client.splash || this.client.utility || this.client.transient)) ||
       this.config.floatingClass.indexOf(resourceClass) >= 0 ||
       this.config.floatingClass.indexOf(resourceName) >= 0 ||
       matchWords(this.client.caption, this.config.floatingTitle) >= 0

--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -129,7 +129,10 @@ export class DriverWindowImpl implements DriverWindow {
       this.client.modal ||
       !this.client.resizeable ||
       (this.config.floatUtility &&
-        (this.client.dialog || this.client.splash || this.client.utility || this.client.transient)) ||
+        (this.client.dialog ||
+         this.client.splash ||
+         this.client.utility ||
+         this.client.transient)) ||
       this.config.floatingClass.indexOf(resourceClass) >= 0 ||
       this.config.floatingClass.indexOf(resourceName) >= 0 ||
       matchWords(this.client.caption, this.config.floatingTitle) >= 0

--- a/src/kwinscript/extern/kwin.d.ts
+++ b/src/kwinscript/extern/kwin.d.ts
@@ -212,12 +212,12 @@ declare namespace KWin {
      * management (moving, raising,...) on them.
      */
     readonly specialWindow: boolean;
-    
+
     /**
      * Whether the windows is transient to an other windows, i.e. it is a sub window belonging to
      * a main window
      */
-    readonly transient: boolean; 
+    readonly transient: boolean;
 
     /**
      * The desktop this window is on. If the window is on all desktops the property has value -1.

--- a/src/kwinscript/extern/kwin.d.ts
+++ b/src/kwinscript/extern/kwin.d.ts
@@ -212,6 +212,12 @@ declare namespace KWin {
      * management (moving, raising,...) on them.
      */
     readonly specialWindow: boolean;
+    
+    /**
+     * Whether the windows is transient to an other windows, i.e. it is a sub window belonging to
+     * a main window
+     */
+    readonly transient: boolean; 
 
     /**
      * The desktop this window is on. If the window is on all desktops the property has value -1.


### PR DESCRIPTION
## Summary

Mark transient windows as utility windows and make them float instead of making them tiled

## Breaking Changes

None

## UI Changes

None

## Test Plan

1. Reload Script...
2. Utility windows such as polkit windows should not be tiled

Some windows are however not marked as transient for some obscure reasons and are still tiled.

## Related Issues

Partially closes #115 
