### PR TITLE
refactor: optimize svg icons

### DIFF
--- a/scripts/optimize-icons.sh
+++ b/scripts/optimize-icons.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
+# SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+# SPDX-License-Identifier: MIT
 
 # Exit immediately on error
 set -eu

--- a/scripts/optimize-icons.sh
+++ b/scripts/optimize-icons.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Exit immediately on error
+set -eu
+
+# Check if scour is installed
+if ! command -v scour &> /dev/null; then
+  echo '"scour" could not be found.' >&2
+  exit 1
+fi
+
+# Determine the absolute path to the repository
+repo_dir_path="$(unset CDPATH && cd "$(dirname "$0")/.." && echo "$PWD")"
+if ! [ "$(basename "${repo_dir_path}")" = bismuth ]; then
+  echo 'Could not determine the absolute path of the repository. Bailing out.' >&2
+  exit 1
+fi
+
+echo 'Optimizing icons...'
+
+for icon in "${repo_dir_path}"/src/kcm/icons/*.svg \
+            "${repo_dir_path}"/src/kwinscript/icons/*.svg; do
+  # File name without leading path and .svg suffix
+  base_name="$(basename "${icon}" .svg)"
+
+  # Append .tmp to unoptimized icon's name
+  mv "${icon}" "${icon}.tmp"
+
+  scour --create-groups                         \
+        --strip-xml-prolog                      \
+        --remove-descriptive-elements           \
+        --enable-viewboxing                     \
+        --nindent 2                             \
+        --strip-xml-space                       \
+        --enable-id-stripping                   \
+        --protect-ids-list=current-color-scheme \
+        -i "${icon}.tmp"                        \
+        -o "${icon}"
+
+  # Remove unoptimized icon
+  rm "${icon}.tmp"
+done
+
+echo 'Done!'

--- a/src/kcm/icons/22-categories-bismuth-kcm.svg
+++ b/src/kcm/icons/22-categories-bismuth-kcm.svg
@@ -3,43 +3,40 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 <svg version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
- <defs>
-  <linearGradient id="b">
-   <stop stop-color="#c6cdd1" offset="0"/>
-   <stop stop-color="#e0e5e7" offset="1"/>
-  </linearGradient>
-  <linearGradient id="d" x1="391.57" x2="406.57" y1="525.8" y2="540.8" gradientTransform="translate(282.55 -343.68)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
-  <linearGradient id="c">
-   <stop offset="0"/>
-   <stop stop-opacity="0" offset="1"/>
-  </linearGradient>
-  <linearGradient id="a" x2="0" y1="543.8" y2="502.66" gradientTransform="matrix(.66667 0 0 .63518 128.19 198.52)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
-  <linearGradient id="f" x1="379.57" x2="407.57" y1="540.8" y2="555.8" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
-  <linearGradient id="e" x1="392.57" x2="401.57" y1="524.8" y2="539.8" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
-  <linearGradient id="g" x2="0" y1="543.8" y2="502.66" gradientTransform="matrix(.66667 0 0 .63518 128.19 198.52)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
- </defs>
- <g transform="translate(-352.57 -511.8)">
-  <rect x="386.57" y="517.8" width="30" height="24" rx="0" fill="url(#a)"/>
-  <path d="m387.57 539.8 28-16 1 1v17h-27z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
-  <rect x="386.57" y="517.8" width="30" height="4" fill="#566069"/>
-  <rect x="386.57" y="521.8" width="30" height="1" fill="#3daee9"/>
-  <rect x="387.57" y="523.8" width="28" height="16" fill="#fff"/>
-  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
- </g>
- <g transform="translate(-385.57 -511.8)">
-  <rect x="385.57" y="517.8" width="30" height="52" rx="0" fill="url(#a)"/>
-  <path d="m386.57 567.8 28-44 1 1v45h-27z" fill="url(#f)" fill-rule="evenodd" opacity=".2"/>
-  <rect x="385.57" y="517.8" width="30" height="4" fill="#566069"/>
-  <rect x="385.57" y="521.8" width="30" height="1" fill="#3daee9"/>
-  <rect x="386.57" y="523.8" width="28" height="44" fill="#fff"/>
-  <rect x="412.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
- </g>
- <g transform="translate(-352.57 -483.8)">
-  <rect x="386.57" y="517.8" width="30" height="24" rx="0" fill="url(#g)"/>
-  <path d="m387.57 539.8 28-16 1 1v17h-27z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
-  <rect x="386.57" y="517.8" width="30" height="4" fill="#566069"/>
-  <rect x="386.57" y="521.8" width="30" height="1" fill="#3daee9"/>
-  <rect x="387.57" y="523.8" width="28" height="16" fill="#fff"/>
-  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
- </g>
+  <defs>
+    <linearGradient id="c">
+      <stop offset="0"/>
+      <stop stop-opacity="0" offset="1"/>
+    </linearGradient>
+    <linearGradient id="a" x2="0" y1="543.8" y2="502.66" gradientTransform="matrix(.66667 0 0 .63518 128.19 198.52)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#c6cdd1" offset="0"/>
+      <stop stop-color="#e0e5e7" offset="1"/>
+    </linearGradient>
+    <linearGradient id="e" x1="392.57" x2="401.57" y1="524.8" y2="539.8" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+    <linearGradient id="f" x1="379.57" x2="407.57" y1="540.8" y2="555.8" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+  </defs>
+  <g transform="translate(-385.57,-511.8)">
+    <rect x="385.57" y="517.8" width="30" height="52" rx="0" fill="url(#a)"/>
+    <path d="m386.57 567.8 28-44 1 1v45h-27z" fill="url(#f)" fill-rule="evenodd" opacity=".2"/>
+    <rect x="385.57" y="517.8" width="30" height="4" fill="#566069"/>
+    <rect x="385.57" y="521.8" width="30" height="1" fill="#3daee9"/>
+    <rect x="386.57" y="523.8" width="28" height="44" fill="#fff"/>
+    <rect x="412.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+  </g>
+  <g transform="translate(-352.57,-511.8)">
+    <rect x="386.57" y="517.8" width="30" height="24" rx="0" fill="url(#a)"/>
+    <path d="m387.57 539.8 28-16 1 1v17h-27z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
+    <rect x="386.57" y="517.8" width="30" height="4" fill="#566069"/>
+    <rect x="386.57" y="521.8" width="30" height="1" fill="#3daee9"/>
+    <rect x="387.57" y="523.8" width="28" height="16" fill="#fff"/>
+    <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+  </g>
+  <g transform="translate(-352.57,-483.8)">
+    <rect x="386.57" y="517.8" width="30" height="24" rx="0" fill="url(#a)"/>
+    <path d="m387.57 539.8 28-16 1 1v17h-27z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
+    <rect x="386.57" y="517.8" width="30" height="4" fill="#566069"/>
+    <rect x="386.57" y="521.8" width="30" height="1" fill="#3daee9"/>
+    <rect x="387.57" y="523.8" width="28" height="16" fill="#fff"/>
+    <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+  </g>
 </svg>

--- a/src/kcm/icons/64-categories-bismuth-kcm.svg
+++ b/src/kcm/icons/64-categories-bismuth-kcm.svg
@@ -3,42 +3,40 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 <svg version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
- <defs>
-  <linearGradient id="b">
-   <stop stop-color="#c6cdd1" offset="0"/>
-   <stop stop-color="#e0e5e7" offset="1"/>
-  </linearGradient>
-  <linearGradient id="d" x1="391.57" x2="406.57" y1="525.8" y2="540.8" gradientTransform="translate(282.55 -343.68)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
-  <linearGradient id="c">
-   <stop offset="0"/>
-   <stop stop-opacity="0" offset="1"/>
-  </linearGradient>
-  <linearGradient id="a" x2="0" y1="543.8" y2="502.66" gradientTransform="matrix(.66667 0 0 .63518 128.19 198.52)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
-  <linearGradient id="e" x1="391.57" x2="400.03" y1="525.8" y2="540.6" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
-  <linearGradient id="f" x1="380.4" x2="408.72" y1="541.17" y2="556.25" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
- </defs>
- <g transform="translate(-352.57 -511.8)">
-  <rect x="385.57" y="517.8" width="31" height="25" rx="0" fill="url(#a)"/>
-  <path d="m386.57 540.8 29-17 1 1-2e-5 18h-28z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
-  <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
-  <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
-  <rect x="386.57" y="523.8" width="29" height="17" fill="#fff"/>
-  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
- </g>
- <g transform="translate(-352.57 -484.8)">
-  <rect x="385.57" y="517.8" width="31" height="25" rx="0" fill="url(#a)"/>
-  <path d="m386.57 540.8 29-17 1 1-2e-5 18h-28z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
-  <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
-  <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
-  <rect x="386.57" y="523.8" width="29" height="17" fill="#fff"/>
-  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
- </g>
- <g transform="translate(-385.57 -511.8)">
-  <rect x="385.57" y="517.8" width="31" height="52" rx="0" fill="url(#a)"/>
-  <path d="m386.57 567.8 29-44 1 1-2e-5 45h-28z" fill="url(#f)" fill-rule="evenodd" opacity=".2"/>
-  <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
-  <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
-  <rect x="386.57" y="523.8" width="29" height="44" fill="#fff"/>
-  <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
- </g>
+  <defs>
+    <linearGradient id="c">
+      <stop offset="0"/>
+      <stop stop-opacity="0" offset="1"/>
+    </linearGradient>
+    <linearGradient id="a" x2="0" y1="543.8" y2="502.66" gradientTransform="matrix(.66667 0 0 .63518 128.19 198.52)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#c6cdd1" offset="0"/>
+      <stop stop-color="#e0e5e7" offset="1"/>
+    </linearGradient>
+    <linearGradient id="e" x1="391.57" x2="400.03" y1="525.8" y2="540.6" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+    <linearGradient id="f" x1="380.4" x2="408.72" y1="541.17" y2="556.25" gradientTransform="translate(-7e-6,2.9e-5)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+  </defs>
+  <g transform="translate(-385.57 -511.8)">
+    <rect x="385.57" y="517.8" width="31" height="52" rx="0" fill="url(#a)"/>
+    <path d="m386.57 567.8 29-44 1 1-2e-5 45h-28z" fill="url(#f)" fill-rule="evenodd" opacity=".2"/>
+    <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
+    <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
+    <rect x="386.57" y="523.8" width="29" height="44" fill="#fff"/>
+    <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+  </g>
+  <g transform="translate(-352.57 -511.8)">
+    <rect x="385.57" y="517.8" width="31" height="25" rx="0" fill="url(#a)"/>
+    <path d="m386.57 540.8 29-17 1 1-2e-5 18h-28z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
+    <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
+    <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
+    <rect x="386.57" y="523.8" width="29" height="17" fill="#fff"/>
+    <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+  </g>
+  <g transform="translate(-352.57 -484.8)">
+    <rect x="385.57" y="517.8" width="31" height="25" rx="0" fill="url(#a)"/>
+    <path d="m386.57 540.8 29-17 1 1-2e-5 18h-28z" fill="url(#e)" fill-rule="evenodd" opacity=".2"/>
+    <rect x="385.57" y="517.8" width="31" height="4" fill="#566069"/>
+    <rect x="385.57" y="521.8" width="31" height="1" fill="#3daee9"/>
+    <rect x="386.57" y="523.8" width="29" height="17" fill="#fff"/>
+    <rect x="413.57" y="518.8" width="2" height="2" rx="1" fill="#eff0f1"/>
+  </g>
 </svg>

--- a/src/kcm/icons/sc-apps-bismuth.svg
+++ b/src/kcm/icons/sc-apps-bismuth.svg
@@ -2,9 +2,9 @@
 SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
 SPDX-License-Identifier: CC-BY-4.0
 -->
-<svg width="300" height="300" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M204 220.5L93 220.5L93 74L103 74L103 210.5L204 210.5L204 220.5Z" fill="#76A694"/>
-<path d="M204 220.5L93 220.5L93 64L78 64L78 235.5L221 235.5L221 156.5L148.5 156.5L148.5 171.5L204 171.5L204 220.5Z" fill="#879B57"/>
-<path d="M241 255.5L58 255.5L58 44L78 44L78 235.5L221 235.5L221 156.5L148.209 156.5L148.209 171.5L128.209 171.5L128 136.5L241 136.5L241 255.5Z" fill="#FFF36B"/>
-<path d="M266 111.5L266 280.5L33 280.5L33 19L58 19L58 255.5L241 255.5L241 136.5L128 136.5L128 210.5L103 210.5L103 111.5L266 111.5Z" fill="#A63F3F"/>
+<svg version="1.1" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+  <path d="m204 220.5h-111v-146.5h10v136.5h101v10z" fill="#76A694"/>
+  <path d="m204 220.5h-111v-156.5h-15v171.5h143v-79h-72.5v15h55.5v49z" fill="#879B57"/>
+  <path d="m241 255.5h-183v-211.5h20v191.5h143v-79h-72.791v15h-20l-0.209-35h113v119z" fill="#FFF36B"/>
+  <path d="m266 111.5v169h-233v-261.5h25v236.5h183v-119h-113v74h-25v-99h163z" fill="#A63F3F"/>
 </svg>

--- a/src/kwinscript/icons/16-status-bismuth-column.svg
+++ b/src/kwinscript/icons/16-status-bismuth-column.svg
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" transform="scale(.5)" fill="currentColor">
+    <rect x="4" y="6" width="6" height="20"/>
+    <rect x="12" y="6" width="8" height="20"/>
+    <rect x="22" y="6" width="6" height="20"/>
+    <path d="m0 2v28h32v-28zm2 2h28v24h-28z"/>
+  </g>
+</svg>

--- a/src/kwinscript/icons/16-status-bismuth-floating.svg
+++ b/src/kwinscript/icons/16-status-bismuth-floating.svg
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" transform="scale(.5)" fill="currentColor">
+    <rect x="4" y="14" width="14" height="12"/>
+    <path d="m0 2v28h32v-28zm2 2h28v24h-28z"/>
+    <path d="m14 6v6h6v6h8v-12z"/>
+  </g>
+</svg>

--- a/src/kwinscript/icons/16-status-bismuth-monocle.svg
+++ b/src/kwinscript/icons/16-status-bismuth-monocle.svg
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" transform="matrix(.5013 0 0 .5013 -.03125 -.036458)" fill="currentColor">
+    <rect x="4.052" y="6.0572" width="23.938" height="19.948"/>
+    <path d="m0.062338 2.0675v27.927h31.917v-27.927zm1.9948 1.9948h27.927v23.938h-27.927z"/>
+  </g>
+</svg>

--- a/src/kwinscript/icons/16-status-bismuth-quarter.svg
+++ b/src/kwinscript/icons/16-status-bismuth-quarter.svg
@@ -1,0 +1,14 @@
+<!--
+SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" transform="scale(.5)" fill="currentColor">
+    <rect x="4" y="18" width="10" height="8"/>
+    <rect x="18" y="6" width="10" height="8"/>
+    <rect x="4" y="6" width="10" height="8"/>
+    <rect x="18" y="18" width="10" height="8"/>
+    <path d="m0 2v28h32v-28zm2 2h28v24h-28z"/>
+  </g>
+</svg>

--- a/src/kwinscript/icons/16-status-bismuth-spiral.svg
+++ b/src/kwinscript/icons/16-status-bismuth-spiral.svg
@@ -1,0 +1,14 @@
+<!--
+SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" transform="scale(.5)" fill="currentColor">
+    <rect x="18" y="18" width="4" height="8"/>
+    <rect x="18" y="6" width="10" height="8"/>
+    <rect x="4" y="6" width="10" height="20"/>
+    <rect x="24" y="18" width="4" height="8"/>
+    <path d="m0 2v28h32v-28zm2 2h28v24h-28z"/>
+  </g>
+</svg>

--- a/src/kwinscript/icons/16-status-bismuth-spread.svg
+++ b/src/kwinscript/icons/16-status-bismuth-spread.svg
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" transform="scale(.5)" fill="currentColor">
+    <rect x="4" y="6" width="16" height="20"/>
+    <rect x="22" y="6" width="2" height="20"/>
+    <rect x="26" y="6" width="2" height="20"/>
+    <path d="m0 2v28h32v-28zm2 2h28v24h-28z"/>
+  </g>
+</svg>

--- a/src/kwinscript/icons/16-status-bismuth-stair.svg
+++ b/src/kwinscript/icons/16-status-bismuth-stair.svg
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" transform="scale(.5)" fill="currentColor">
+    <rect x="4" y="10" width="20" height="16"/>
+    <path d="m0 2v28h32v-28zm2 2h28v24h-28z"/>
+    <path d="m6 6v2h20v16h2v-18z"/>
+  </g>
+</svg>

--- a/src/kwinscript/icons/16-status-bismuth-tile.svg
+++ b/src/kwinscript/icons/16-status-bismuth-tile.svg
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2022 Ignacy Kajdan <git@verahawk.com>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" transform="scale(.5)" fill="currentColor">
+    <rect x="18" y="6" width="10" height="8"/>
+    <rect x="4" y="6" width="10" height="20"/>
+    <rect x="18" y="18" width="10" height="8"/>
+    <path d="m0 2v28h32v-28zm2 2h28v24h-28z"/>
+  </g>
+</svg>

--- a/src/kwinscript/icons/32-status-bismuth-column.svg
+++ b/src/kwinscript/icons/32-status-bismuth-column.svg
@@ -3,17 +3,11 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
- <style id="current-color-scheme" type="text/css">
-  .ColorScheme-Text { color:#eff0f1; }
- </style>
- <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
-  <rect x="1.3636" y="5.2" width="9.5455" height="21.6" stroke-width=".76376"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
-  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="13.636" y="5.2" width="10.909" height="21.6" stroke-width=".81649"/>
-  <rect x="27.273" y="5.2001" width="9.5455" height="21.6" stroke-width=".76376"/>
- </g>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" fill="currentColor">
+    <rect x="3" y="7" width="7" height="18"/>
+    <rect x="12" y="7" width="8" height="18"/>
+    <rect x="22" y="7" width="7" height="18"/>
+    <path d="m0 4v24h32v-24zm1 1h30v22h-30z"/>
+  </g>
 </svg>

--- a/src/kwinscript/icons/32-status-bismuth-floating.svg
+++ b/src/kwinscript/icons/32-status-bismuth-floating.svg
@@ -3,16 +3,10 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
- <style id="current-color-scheme" type="text/css">
-  .ColorScheme-Text { color:#eff0f1; }
- </style>
- <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
-  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
-  <path d="m15 5.2v6h9.5455v8.4h12.273v-14.4z" stroke-width=".95742"/>
-  <rect x="1.3636" y="12.4" width="21.818" height="14.4" stroke-width=".9428"/>
- </g>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" fill="currentColor">
+    <rect x="3" y="13" width="16" height="12"/>
+    <path d="m0 4v24h32v-24zm1 1h30v22h-30z"/>
+    <path d="m13 7v5h7v7h9v-12z"/>
+  </g>
 </svg>

--- a/src/kwinscript/icons/32-status-bismuth-monocle.svg
+++ b/src/kwinscript/icons/32-status-bismuth-monocle.svg
@@ -3,15 +3,9 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
- <style id="current-color-scheme" type="text/css">
-  .ColorScheme-Text { color:#eff0f1; }
- </style>
- <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
-  <rect x="1.3636" y="5.2" width="35.455" height="21.6" stroke-width="1.472"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
-  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
- </g>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" fill="currentColor">
+    <rect x="3" y="7" width="26" height="18"/>
+    <path d="m0 4v24h32v-24zm1 1h30v22h-30z"/>
+  </g>
 </svg>

--- a/src/kwinscript/icons/32-status-bismuth-quarter.svg
+++ b/src/kwinscript/icons/32-status-bismuth-quarter.svg
@@ -3,18 +3,12 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
- <style id="current-color-scheme" type="text/css">
-  .ColorScheme-Text { color:#eff0f1; }
- </style>
- <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
-  <rect x="1.3636" y="17.2" width="16.364" height="9.6" stroke-width=".66667"/>
-  <rect x="20.455" y="5.2" width="16.364" height="9.6"/>
-  <rect x="20.455" y="17.2" width="16.364" height="9.6"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
-  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="1.3636" y="5.2" width="16.364" height="9.6" stroke-width=".66667"/>
- </g>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" fill="currentColor">
+    <rect x="3" y="17" width="12" height="8"/>
+    <rect x="17" y="7" width="12" height="8"/>
+    <rect x="3" y="7" width="12" height="8"/>
+    <rect x="17" y="17" width="12" height="8"/>
+    <path d="m0 4v24h32v-24zm1 1h30v22h-30z"/>
+  </g>
 </svg>

--- a/src/kwinscript/icons/32-status-bismuth-spiral.svg
+++ b/src/kwinscript/icons/32-status-bismuth-spiral.svg
@@ -3,18 +3,12 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
- <style id="current-color-scheme" type="text/css">
-  .ColorScheme-Text { color:#eff0f1; }
- </style>
- <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
-  <rect x="1.3636" y="5.2" width="16.364" height="21.6"/>
-  <rect x="20.455" y="5.2" width="16.364" height="9.6"/>
-  <rect x="20.455" y="17.2" width="6.8179" height="9.6" stroke-width=".64547"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
-  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="30" y="17.2" width="6.8189" height="9.6" stroke-width=".64552"/>
- </g>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" fill="currentColor">
+    <rect x="17" y="17" width="5" height="8"/>
+    <rect x="17" y="7" width="12" height="8"/>
+    <rect x="3" y="7" width="12" height="18"/>
+    <rect x="24" y="17" width="5" height="8"/>
+    <path d="m0 4v24h32v-24zm1 1h30v22h-30z"/>
+  </g>
 </svg>

--- a/src/kwinscript/icons/32-status-bismuth-spread.svg
+++ b/src/kwinscript/icons/32-status-bismuth-spread.svg
@@ -3,17 +3,11 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
- <style id="current-color-scheme" type="text/css">
-  .ColorScheme-Text { color:#eff0f1; }
- </style>
- <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
-  <rect x="1.3636" y="5.2" width="30" height="21.6" stroke-width="1.354"/>
-  <rect x="32.727" y="5.2" width="1.3643" height="21.6" stroke-width=".43311"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
-  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="35.455" y="5.2" width="1.3643" height="21.6" stroke-width=".43311"/>
- </g>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" fill="currentColor">
+    <rect x="3" y="7" width="22" height="18"/>
+    <rect x="26" y="7" width="1" height="18"/>
+    <rect x="28" y="7" width="1" height="18"/>
+    <path d="m0 4v24h32v-24zm1 1h30v22h-30z"/>
+  </g>
 </svg>

--- a/src/kwinscript/icons/32-status-bismuth-stair.svg
+++ b/src/kwinscript/icons/32-status-bismuth-stair.svg
@@ -3,16 +3,10 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
- <style id="current-color-scheme" type="text/css">
-  .ColorScheme-Text { color:#eff0f1; }
- </style>
- <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
-  <rect x="1.3636" y="7.6" width="32.727" height="19.2" stroke-width="1.3333"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
-  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
-  <path d="m2.7273 5.2v1.2h32.727v19.2h1.3636v-20.4z" stroke-width="1.4027"/>
- </g>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" fill="currentColor">
+    <rect x="3" y="9" width="24" height="16"/>
+    <path d="m0 4v24h32v-24zm1 1h30v22h-30z"/>
+    <path d="m4 7v1h24v16h1v-17z"/>
+  </g>
 </svg>

--- a/src/kwinscript/icons/32-status-bismuth-tile.svg
+++ b/src/kwinscript/icons/32-status-bismuth-tile.svg
@@ -3,17 +3,11 @@ SPDX-FileCopyrightText: 2021 Ignacy Kajdan <git@verahawk.com>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
- <style id="current-color-scheme" type="text/css">
-  .ColorScheme-Text { color:#eff0f1; }
- </style>
- <g class="ColorScheme-Text" transform="matrix(.73333 0 0 .83333 2 2.6667)" fill="currentColor">
-  <rect x="1.3636" y="5.2" width="16.364" height="21.6"/>
-  <rect x="20.455" y="5.2" width="16.364" height="9.6"/>
-  <rect x="20.455" y="17.2" width="16.364" height="9.6"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="1.6" width="43.636" height="1.2"/>
-  <rect x="-2.7273" y="29.2" width="43.636" height="1.2"/>
-  <rect x="39.545" y="1.6" width="1.3636" height="28.8"/>
-  <rect x="-2.7273" y="1.6" width="1.3636" height="28.8"/>
- </g>
+  <style id="current-color-scheme" type="text/css">.ColorScheme-Text { color:#eff0f1; }</style>
+  <g class="ColorScheme-Text" fill="currentColor">
+    <rect x="17" y="7" width="12" height="8"/>
+    <rect x="3" y="7" width="12" height="18"/>
+    <rect x="17" y="17" width="12" height="8"/>
+    <path d="m0 4v24h32v-24zm1 1h30v22h-30z"/>
+  </g>
 </svg>

--- a/src/kwinscript/icons/CMakeLists.txt
+++ b/src/kwinscript/icons/CMakeLists.txt
@@ -3,6 +3,14 @@
 
 ecm_install_icons(
   ICONS
+  16-status-bismuth-column.svg
+  16-status-bismuth-floating.svg
+  16-status-bismuth-monocle.svg
+  16-status-bismuth-quarter.svg
+  16-status-bismuth-spiral.svg
+  16-status-bismuth-spread.svg
+  16-status-bismuth-stair.svg
+  16-status-bismuth-tile.svg
   32-status-bismuth-column.svg
   32-status-bismuth-floating.svg
   32-status-bismuth-monocle.svg


### PR DESCRIPTION
Optimizes all SVG icons using scour. Adds a bash script for optimizing any future icons. 

Also adds 16px version of layout icons (to be used in applet's context menu):

![context_menu](https://user-images.githubusercontent.com/28950897/153606518-0d8a53d3-4835-45cc-964f-3b5edafdac20.png)

This shouldn't change the appearance of any icon.


