### PR TITLE
Add signal forwarding for Plasma (KWin) API

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,6 @@ set -e
 
 echo "🏗️ Building Bismuth..."
 
-cmake -S "." -B "build" -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_TESTING=false
+cmake -S "." -B "build" -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 cmake --build "build"
 ln -sf "$PWD/build/compile_commands.json" "./compile_commands.json" # For LSP

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,13 +7,13 @@ set -e
 
 echo "🏗️ Building Bismuth Testing Build..."
 
-cmake -S "." -B "build/testing" -G Ninja \
+cmake -S "." -B "build" -G Ninja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   -DBUILD_TESTING=true
 
-cmake --build "build/testing"
+cmake --build "build"
 
 echo "🧪 Testing Bismuth..."
 
-build/testing/bin/test_runner
+build/bin/test_runner

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -39,13 +39,6 @@ target_link_libraries(
   KF5::I18n
 )
 
-target_compile_definitions(
-  bismuth_core
-  PRIVATE
-  # Make all Doctest symbols exported
-  DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
-)
-
 kconfig_add_kcfg_files(bismuth_core GENERATE_MOC "config.kcfgc")
 
 ecm_qt_install_logging_categories(

--- a/src/core/plasma-api/client.cpp
+++ b/src/core/plasma-api/client.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#include "client.hpp"
+#include "toplevel.hpp"
+
+namespace PlasmaApi
+{
+
+Client::Client(QObject *kwinImpl)
+    : TopLevel(kwinImpl){};
+
+Client::Client(const Client &rhs)
+    : TopLevel(rhs){};
+}

--- a/src/core/plasma-api/client.hpp
+++ b/src/core/plasma-api/client.hpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <QList>
+#include <QObject>
+#include <QRect>
+#include <QString>
+
+#include "toplevel.hpp"
+
+namespace PlasmaApi
+{
+class Client : TopLevel
+{
+    Q_OBJECT
+
+public:
+    Client() = default;
+    Client(QObject *kwinImpl);
+    Client(const Client &);
+    virtual ~Client() = default;
+
+    /**
+     * The activities this client is on. If it's on all activities the property is empty.
+     */
+    // Q_PROPERTY(QStringList activities READ activities)
+    // QSTRINGLIST_PRIMITIVE_SETGET(activities)
+    //
+    // /**
+    //  * Whether the window is active.
+    //  */
+    // Q_PROPERTY(bool active READ active)
+    // BOOL_PRIMITIVE_GET(active)
+    //
+    // /**
+    //  * Window caption (The text in the titlebar).
+    //  */
+    // Q_PROPERTY(QString caption READ caption)
+    // QSTRING_PRIMITIVE_GET(caption)
+    //
+    // /**
+    //  * Maximum allowed size for a window.
+    //  */
+    // Q_PROPERTY(QSize maxSize READ maxSize)
+    // QSIZE_PRIMITIVE_GET(maxSize)
+    //
+    // /**
+    //  * Minimum allowed size for a window.
+    //  */
+    // Q_PROPERTY(QSize minSize READ minSize)
+    // QSIZE_PRIMITIVE_GET(minSize)
+    //
+    // /**
+    //  * Whether the window is modal or not.
+    //  */
+    // Q_PROPERTY(bool modal READ modal)
+    // BOOL_PRIMITIVE_GET(modal)
+    //
+    // /**
+    //  * Whether the window is currently being moved by the user.
+    //  */
+    // Q_PROPERTY(bool move READ move)
+    // BOOL_PRIMITIVE_GET(move)
+    //
+    // /**
+    //  * Whether the window is currently being resized by the user.
+    //  */
+    // Q_PROPERTY(bool resize READ resize)
+    // BOOL_PRIMITIVE_GET(resize)
+    //
+    // /**
+    //  * Whether the window is resizable
+    //  */
+    // Q_PROPERTY(bool resizable READ resizable)
+    // BOOL_PRIMITIVE_GET(resizable)
+    //
+    // /**
+    //  * Whether the window is any of special windows types (desktop, dock, splash, ...),
+    //  * i.e. window types that usually don't have a window frame and the user does not use window
+    //  * management (moving, raising,...) on them.
+    //  */
+    // Q_PROPERTY(bool specialWindow READ specialWindow)
+    // BOOL_PRIMITIVE_GET(specialWindow)
+    //
+    // /**
+    //  * The desktop this window is on. If the window is on all desktops the property has value -1.
+    //  */
+    // Q_PROPERTY(int desktop READ desktop WRITE set_desktop)
+    // INT_PRIMITIVE_SETGET(desktop)
+    //
+    // /**
+    //  * Whether the window is fullscreen
+    //  */
+    // Q_PROPERTY(bool fullScreen READ fullScreen WRITE set_fullScreen)
+    // BOOL_PRIMITIVE_SETGET(fullScreen)
+    //
+    // /**
+    //  * Whether the window is set to be above all
+    //  */
+    // Q_PROPERTY(bool keepAbove READ keepAbove WRITE set_keepAbove)
+    // BOOL_PRIMITIVE_SETGET(keepAbove)
+    //
+    // /**
+    //  * Whether the window is set to be below all
+    //  */
+    // Q_PROPERTY(bool keepBelow READ keepBelow WRITE set_keepBelow)
+    // BOOL_PRIMITIVE_SETGET(keepBelow)
+    //
+    // /**
+    //  * Whether the window is minimized
+    //  */
+    // Q_PROPERTY(bool minimized READ minimized WRITE set_minimized)
+    // BOOL_PRIMITIVE_SETGET(minimized)
+    //
+    // /**
+    //  * Whether the window has borders (window decorations)
+    //  */
+    // Q_PROPERTY(bool noBorder READ noBorder WRITE set_noBorder)
+    // BOOL_PRIMITIVE_SETGET(noBorder)
+    //
+    // /**
+    //  * Whether the window is set to be on all desktops
+    //  */
+    // Q_PROPERTY(bool onAllDesktops READ onAllDesktops WRITE set_onAllDesktops)
+    // BOOL_PRIMITIVE_SETGET(onAllDesktops)
+    //
+    // /**
+    //  * Whether the Client is shaded.
+    //  */
+    // Q_PROPERTY(bool shade READ shade WRITE set_shade)
+    // BOOL_PRIMITIVE_SETGET(shade)
+};
+
+}
+
+Q_DECLARE_METATYPE(PlasmaApi::Client);

--- a/src/core/plasma-api/plasma-api.cpp
+++ b/src/core/plasma-api/plasma-api.cpp
@@ -11,12 +11,12 @@ namespace PlasmaApi
 {
 
 PlasmaApi::PlasmaApi(QQmlEngine *engine)
-    : m_engine(engine){};
+    : m_engine(engine)
+    , m_workspace(engine){};
 
-Workspace PlasmaApi::workspace()
+Workspace &PlasmaApi::workspace()
 {
-    auto evalResult = m_engine->globalObject().property("workspace");
-    return Workspace(evalResult, m_engine);
+    return m_workspace;
 }
 
 }

--- a/src/core/plasma-api/plasma-api.cpp
+++ b/src/core/plasma-api/plasma-api.cpp
@@ -12,7 +12,10 @@ namespace PlasmaApi
 
 PlasmaApi::PlasmaApi(QQmlEngine *engine)
     : m_engine(engine)
-    , m_workspace(engine){};
+    , m_workspace(engine)
+{
+    qRegisterMetaType<Client>();
+};
 
 Workspace &PlasmaApi::workspace()
 {

--- a/src/core/plasma-api/plasma-api.hpp
+++ b/src/core/plasma-api/plasma-api.hpp
@@ -16,10 +16,11 @@ namespace PlasmaApi
 struct PlasmaApi {
     explicit PlasmaApi(QQmlEngine *engine);
 
-    Workspace workspace();
+    Workspace &workspace();
 
 private:
     QQmlEngine *m_engine;
+    Workspace m_workspace;
 };
 
 }

--- a/src/core/plasma-api/toplevel.cpp
+++ b/src/core/plasma-api/toplevel.cpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#include "toplevel.hpp"
+
+namespace PlasmaApi
+{
+
+TopLevel::TopLevel(QObject *kwinImpl)
+    : m_kwinImpl(kwinImpl){};
+
+TopLevel::TopLevel(const TopLevel &rhs)
+    : m_kwinImpl(rhs.m_kwinImpl){};
+}

--- a/src/core/plasma-api/toplevel.hpp
+++ b/src/core/plasma-api/toplevel.hpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <QObject>
+
+namespace PlasmaApi
+{
+
+class TopLevel : public QObject
+{
+    Q_OBJECT
+public:
+    TopLevel() = default;
+    explicit TopLevel(QObject *kwinImplPtr);
+    TopLevel(const TopLevel &);
+    virtual ~TopLevel() = default;
+
+    /**
+     * Whether the window is a dialog window.
+     */
+    // Q_PROPERTY(bool dialog READ dialog)
+    // BOOL_PRIMITIVE_GET(dialog)
+    //
+    // /**
+    //  * Frame geometry
+    //  */
+    // // Q_PROPERTY(QRect frameGeometry READ frameGeometry WRITE set_frameGeometry)
+    // // QRECT_
+    //
+    // /**
+    //  * Window class name
+    //  */
+    // Q_PROPERTY(QByteArray resourceClass READ resourceClass)
+    // QBYTEARRAY_PRIMITIVE_GET(resourceClass)
+    //
+    // /**
+    //  * Window title
+    //  */
+    // Q_PROPERTY(QByteArray resourceName READ resourceName)
+    // QBYTEARRAY_PRIMITIVE_GET(resourceName)
+    //
+    // /**
+    //  * On which screen toplevel is
+    //  */
+    // Q_PROPERTY(int screen READ screen)
+    // INT_PRIMITIVE_GET(screen)
+    //
+    // /**
+    //  * Whether the window is a splashscreen.
+    //  */
+    // Q_PROPERTY(bool splash READ splash)
+    // BOOL_PRIMITIVE_GET(splash)
+    //
+    // /**
+    //  * Whether the window is a utility window, such as a tool window.
+    //  */
+    // Q_PROPERTY(bool utility READ utility)
+    // BOOL_PRIMITIVE_GET(utility)
+    //
+    // /**
+    //  * Window id in KWin
+    //  */
+    // Q_PROPERTY(int windowId READ windowId)
+    // INT_PRIMITIVE_GET(windowId)
+    //
+    // /**
+    //  * Window role property
+    //  */
+    // Q_PROPERTY(QByteArray windowRole READ windowRole)
+    // QBYTEARRAY_PRIMITIVE_GET(windowRole)
+    //
+    // /**
+    //  * Client position
+    //  */
+    // Q_PROPERTY(QPoint clientPos READ clientPos)
+    // QPOINT_PRIMITIVE_GET(clientPos)
+    //
+    // /**
+    //  * Client size
+    //  */
+    // Q_PROPERTY(QSize clientSize READ clientSize)
+    // QSIZE_PRIMITIVE_GET(clientSize)
+
+protected:
+    QObject *m_kwinImpl;
+};
+
+}
+
+Q_DECLARE_METATYPE(PlasmaApi::TopLevel);

--- a/src/core/plasma-api/workspace.cpp
+++ b/src/core/plasma-api/workspace.cpp
@@ -18,7 +18,12 @@ Workspace::Workspace(QQmlEngine *engine)
 
 int Workspace::currentDesktop()
 {
-    return m_kwinImpl->property("currentDesktop").toInt();
+    return m_kwinImpl->property("currentDesktop").value<int>();
+}
+
+void Workspace::setCurrentDesktop(int desktop)
+{
+    m_kwinImpl->setProperty("currentDesktop", QVariant::fromValue(desktop));
 }
 
 namespace Test
@@ -41,6 +46,26 @@ TEST_CASE("Workspace Properties Read")
         CHECK(result == 42);
     }
 }
+
+TEST_CASE("Workspace Properties Write")
+{
+    auto engine = QQmlEngine();
+    auto mockWorkspace = MockWorkspaceJS();
+
+    engine.globalObject().setProperty(QStringLiteral("workspace"), engine.newQObject(&mockWorkspace));
+
+    auto plasmaApi = ::PlasmaApi::PlasmaApi(&engine);
+    auto workspace = plasmaApi.workspace();
+
+    workspace.setCurrentDesktop(67);
+
+    SUBCASE("currentDesktop")
+    {
+        auto result = workspace.currentDesktop();
+        CHECK(result == 67);
+    }
+}
+
 }
 
 }

--- a/src/core/plasma-api/workspace.cpp
+++ b/src/core/plasma-api/workspace.cpp
@@ -10,16 +10,15 @@
 namespace PlasmaApi
 {
 
-Workspace::Workspace(const QJSValue &jsRepr, QQmlEngine *engine)
-    : m_jsRepr(jsRepr)
-    , m_engine(engine)
+Workspace::Workspace(QQmlEngine *engine)
+    : m_engine(engine)
+    , m_kwinImpl(engine->globalObject().property("workspace").toQObject())
 {
 }
 
 int Workspace::currentDesktop()
 {
-    auto jsResult = m_jsRepr.property("currentDesktop");
-    return jsResult.toInt();
+    return m_kwinImpl->property("currentDesktop").toInt();
 }
 
 namespace Test
@@ -29,6 +28,7 @@ TEST_CASE("Workspace Properties Read")
 {
     auto engine = QQmlEngine();
     auto mockWorkspace = MockWorkspaceJS();
+    mockWorkspace.setCurrentDesktop(42);
 
     engine.globalObject().setProperty(QStringLiteral("workspace"), engine.newQObject(&mockWorkspace));
 

--- a/src/core/plasma-api/workspace.cpp
+++ b/src/core/plasma-api/workspace.cpp
@@ -3,6 +3,8 @@
 
 #include "workspace.hpp"
 
+#include <QQmlContext>
+
 #include "logger.hpp"
 #include "plasma-api/client.hpp"
 #include "plasma-api/plasma-api.hpp"
@@ -13,7 +15,7 @@ namespace PlasmaApi
 Workspace::Workspace(QQmlEngine *engine)
     : QObject()
     , m_engine(engine)
-    , m_kwinImpl(engine->globalObject().property("workspace").toQObject())
+    , m_kwinImpl(m_engine->rootContext()->contextProperty(QStringLiteral("workspace")).value<QObject *>())
 {
     wrapSignals();
 }

--- a/src/core/plasma-api/workspace.hpp
+++ b/src/core/plasma-api/workspace.hpp
@@ -3,19 +3,19 @@
 
 #pragma once
 
-#include <QJSValue>
+#include <QObject>
 #include <QQmlEngine>
 
 namespace PlasmaApi
 {
 struct Workspace {
-    Workspace(const QJSValue &jsRepr, QQmlEngine *engine);
+    Workspace(QQmlEngine *engine);
 
     int currentDesktop();
 
 private:
-    QJSValue m_jsRepr;
     QQmlEngine *m_engine;
+    QObject *m_kwinImpl;
 };
 
 namespace Test
@@ -23,12 +23,19 @@ namespace Test
 class MockWorkspaceJS : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(int currentDesktop READ currentDesktop)
+    Q_PROPERTY(int currentDesktop READ currentDesktop WRITE setCurrentDesktop)
 public:
     int currentDesktop()
     {
-        return 42;
+        return m_currentDesktop;
     }
+
+    void setCurrentDesktop(int desktop)
+    {
+        m_currentDesktop = desktop;
+    }
+
+    int m_currentDesktop{};
 };
 }
 

--- a/src/core/plasma-api/workspace.hpp
+++ b/src/core/plasma-api/workspace.hpp
@@ -6,38 +6,37 @@
 #include <QObject>
 #include <QQmlEngine>
 
+#include "plasma-api/client.hpp"
+
+// Forward declare KWin Classes
+namespace KWin
+{
+class AbstractClient;
+}
+
 namespace PlasmaApi
 {
-struct Workspace {
+class Workspace : public QObject
+{
+    Q_OBJECT
+public:
     Workspace(QQmlEngine *engine);
+    Workspace(const Workspace &);
 
     int currentDesktop();
     void setCurrentDesktop(int desktop);
 
+public Q_SLOTS:
+    void currentDesktopChangedTransformer(int desktop, KWin::AbstractClient *kwinClient);
+
+Q_SIGNALS:
+    void currentDesktopChanged(int desktop, PlasmaApi::Client kwinClient);
+
 private:
+    void wrapSignals();
+
     QQmlEngine *m_engine;
     QObject *m_kwinImpl;
 };
-
-namespace Test
-{
-class MockWorkspaceJS : public QObject
-{
-    Q_OBJECT
-    Q_PROPERTY(int currentDesktop READ currentDesktop WRITE setCurrentDesktop)
-public:
-    int currentDesktop()
-    {
-        return m_currentDesktop;
-    }
-
-    void setCurrentDesktop(int desktop)
-    {
-        m_currentDesktop = desktop;
-    }
-
-    int m_currentDesktop{};
-};
-}
 
 }

--- a/src/core/plasma-api/workspace.hpp
+++ b/src/core/plasma-api/workspace.hpp
@@ -12,6 +12,7 @@ struct Workspace {
     Workspace(QQmlEngine *engine);
 
     int currentDesktop();
+    void setCurrentDesktop(int desktop);
 
 private:
     QQmlEngine *m_engine;

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -8,6 +8,8 @@ target_sources(test_runner
   main.cpp
 )
 
+add_subdirectory(plasma-api)
+
 target_link_libraries(test_runner
   PRIVATE
   Qt5::Core

--- a/tests/core/plasma-api/CMakeLists.txt
+++ b/tests/core/plasma-api/CMakeLists.txt
@@ -1,11 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@genda.life>
 # SPDX-License-Identifier: MIT
 
-target_sources(
-  bismuth_core
+target_sources(test_runner
   PRIVATE
-  plasma-api.cpp
-  client.cpp
-  toplevel.cpp
   workspace.cpp
 )

--- a/tests/core/plasma-api/workspace.cpp
+++ b/tests/core/plasma-api/workspace.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@genda.life>
+// SPDX-License-Identifier: MIT
+
+#include <doctest/doctest.h>
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QSignalSpy>
+
+#include "plasma-api/client.hpp"
+#include "plasma-api/plasma-api.hpp"
+#include "plasma-api/workspace.hpp"
+
+// Mock KWin Objects. This is for tests only.
+namespace KWin
+{
+class AbstractClient
+{
+};
+}
+
+Q_DECLARE_METATYPE(KWin::AbstractClient *)
+
+class MockWorkspaceJS : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int currentDesktop READ currentDesktop WRITE setCurrentDesktop)
+public:
+    int currentDesktop()
+    {
+        return m_currentDesktop;
+    }
+
+    void setCurrentDesktop(int desktop)
+    {
+        m_currentDesktop = desktop;
+    }
+
+Q_SIGNALS:
+    void currentDesktopChanged(int desktop, KWin::AbstractClient *client);
+
+private:
+    int m_currentDesktop{};
+};
+
+TEST_CASE("Workspace Properties Read")
+{
+    auto engine = QQmlEngine();
+    auto mockWorkspace = MockWorkspaceJS();
+    mockWorkspace.setCurrentDesktop(42);
+
+    engine.globalObject().setProperty(QStringLiteral("workspace"), engine.newQObject(&mockWorkspace));
+
+    auto plasmaApi = ::PlasmaApi::PlasmaApi(&engine);
+    auto workspace = plasmaApi.workspace();
+
+    SUBCASE("currentDesktop")
+    {
+        auto result = workspace.currentDesktop();
+        CHECK(result == 42);
+    }
+}
+
+TEST_CASE("Workspace Properties Write")
+{
+    auto engine = QQmlEngine();
+    auto mockWorkspace = MockWorkspaceJS();
+
+    engine.globalObject().setProperty(QStringLiteral("workspace"), engine.newQObject(&mockWorkspace));
+
+    auto plasmaApi = ::PlasmaApi::PlasmaApi(&engine);
+    auto workspace = plasmaApi.workspace();
+
+    workspace.setCurrentDesktop(67);
+
+    SUBCASE("currentDesktop")
+    {
+        auto result = workspace.currentDesktop();
+        CHECK(result == 67);
+    }
+}
+
+TEST_CASE("Workspace Properties Signals")
+{
+    auto engine = QQmlEngine();
+    auto mockWorkspace = MockWorkspaceJS();
+
+    engine.globalObject().setProperty(QStringLiteral("workspace"), engine.newQObject(&mockWorkspace));
+
+    auto plasmaApi = ::PlasmaApi::PlasmaApi(&engine);
+    auto workspace = plasmaApi.workspace();
+
+    SUBCASE("currentDesktop")
+    {
+        qRegisterMetaType<KWin::AbstractClient *>();
+        auto signalSpy = QSignalSpy(&workspace, SIGNAL(currentDesktopChanged(int, PlasmaApi::Client)));
+        auto mockKWinClient = KWin::AbstractClient();
+
+        // Act
+        Q_EMIT mockWorkspace.currentDesktopChanged(69, &mockKWinClient);
+
+        // Assert
+        CHECK(signalSpy.count() == 1);
+
+        auto signal = signalSpy.takeFirst();
+        auto desktopNum = signal.at(0).value<int>();
+        auto clientVariant = signal.at(1);
+
+        CHECK(desktopNum == 69);
+        CHECK(clientVariant.canConvert<PlasmaApi::Client>());
+    }
+}
+
+#include "workspace.moc"

--- a/tests/core/plasma-api/workspace.cpp
+++ b/tests/core/plasma-api/workspace.cpp
@@ -4,6 +4,7 @@
 #include <doctest/doctest.h>
 
 #include <QObject>
+#include <QQmlContext>
 #include <QQmlEngine>
 #include <QSignalSpy>
 
@@ -49,7 +50,7 @@ TEST_CASE("Workspace Properties Read")
     auto mockWorkspace = MockWorkspaceJS();
     mockWorkspace.setCurrentDesktop(42);
 
-    engine.globalObject().setProperty(QStringLiteral("workspace"), engine.newQObject(&mockWorkspace));
+    engine.rootContext()->setContextProperty(QStringLiteral("workspace"), &mockWorkspace);
 
     auto plasmaApi = ::PlasmaApi::PlasmaApi(&engine);
     auto workspace = plasmaApi.workspace();
@@ -66,7 +67,7 @@ TEST_CASE("Workspace Properties Write")
     auto engine = QQmlEngine();
     auto mockWorkspace = MockWorkspaceJS();
 
-    engine.globalObject().setProperty(QStringLiteral("workspace"), engine.newQObject(&mockWorkspace));
+    engine.rootContext()->setContextProperty(QStringLiteral("workspace"), &mockWorkspace);
 
     auto plasmaApi = ::PlasmaApi::PlasmaApi(&engine);
     auto workspace = plasmaApi.workspace();
@@ -85,7 +86,7 @@ TEST_CASE("Workspace Properties Signals")
     auto engine = QQmlEngine();
     auto mockWorkspace = MockWorkspaceJS();
 
-    engine.globalObject().setProperty(QStringLiteral("workspace"), engine.newQObject(&mockWorkspace));
+    engine.rootContext()->setContextProperty(QStringLiteral("workspace"), &mockWorkspace);
 
     auto plasmaApi = ::PlasmaApi::PlasmaApi(&engine);
     auto workspace = plasmaApi.workspace();


### PR DESCRIPTION
## Summary

Actually, a bunch of stuff:
- Tests were moved into the separate binary
- API now wraps around QObject* KWin implementation pointers and not QJSValues.
- API is tested against context properties and not JS globalObject. The latter does not work in the QML KWin scripts.

## Test Plan

This was tested by connecting the new signal to a lambda with a log. So far it works.
