### PR TITLE
fix: add zoom windows to the default ignore list

### DIFF
--- a/src/config/bismuth_config.kcfg
+++ b/src/config/bismuth_config.kcfg
@@ -57,7 +57,7 @@
 
     <entry name="ignoreClass" type="String">
 	    <label>Ignore windows with certain classes(comma-separated list)</label>
-      <default>yakuake,spectacle,Conky</default>
+      <default>yakuake,spectacle,Conky,zoom</default>
     </entry>
 
     <entry name="ignoreRole" type="String">


### PR DESCRIPTION
## Summary

Since zoom makes its popups with wrong WM props, it's a good candidate
for the default ignore list.

## Related Issues

Closes #274 
