### PR TITLE
chore: move npm scripts to makefile

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           npm install
-          npm run docs
+          make docs
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           npm install
           .github/scripts/sysdep-install.sh
-          npm run build
+          make build
 
   test:
     name: Unit Tests
@@ -92,4 +92,4 @@ jobs:
         run: |
           npm install
           .github/scripts/sysdep-install.sh
-          npm test
+          make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,64 +26,50 @@ To make sure you can develop the script install all the tools you need:
 To prepare environment, clone the project and execute the following:
 
 ```sh
-pre-commit install
-npm install # Install development dependencies
-npm run sysdep-install # Install system dependencies
+make setup-dev-env
 ```
 
-This will install all the things you need, including TypeScript compiler, Unit
-Testing framework and so fore so on.
+This will install and set up all the things you need (Git Hooks, Dependencies).
 
 ## 🔨 Compile Bismuth
 
 To compile Bismuth execute the following:
 
 ```sh
-npm run build
+make build
 ```
 
 This will compile the script via TypeScript and produce the JS output adapted to
-[QML Javascript Environment](https://doc.qt.io/qt-5/qtqml-javascript-hostenvironment.html).
+[QML JavaScript Environment](https://doc.qt.io/qt-5/qtqml-javascript-hostenvironment.html).
 
 ## 📦 Installation
 
 To install compiled package, execute:
 
 ```sh
-npm run bi-install
+make install
 ```
 
 Note however, that if you have the script already installed and enabled, you need to
-restart KWin, so that it can apply the changes you've made. To do so you have a
-convenient script too:
+restart KWin, so that it can apply the changes you've made. To do so do:
 
 ```sh
-npm run install-and-restart-kwin-x11
+make restart-kwin-x11
 ```
-
-This will run the previous steps for you and restart KWin, if you're using X11 session.
-After you quit the restarted KWin, it will automatically restart in the background, so
-that you working session remains in tact.
 
 You can uninstall the package using the following command:
 
 ```sh
-npm run bi-uninstall
+make uninstall
 ```
 
 ## 🧪 Unit testing
 
-Bismuth comes with unit tests. To run them execute the standard npm command:
+Bismuth comes with unit tests. To run them execute the following:
 
 ```sh
-npm test
+make tests
 ```
-
-There is an important note, regarding the unit testing. All the tests are run
-on the Node.js environment. Basically, it means that the global environment you
-see in unit-tests and the global environment you see in the script, while it is
-running in KWin scripting environment, are not the same. Because of this we
-minimize the usage of global object in the code, and you should do the same.
 
 ## 📑 API Documentation
 
@@ -93,24 +79,10 @@ minimize the usage of global object in the code, and you should do the same.
 To generate API docs, run the following:
 
 ```sh
-npm run docs
+make docs
 ```
 
-This will generate the documentation via TypeDoc in the build directory.
-
-## 😥 This seems complicated
-
-Don't worry. The npm commands from the above depend on each other. That means
-that in a typical development workflow you will need only to run of them.
-For example, if I want to manually test the script after some changes, I run:
-
-```sh
-npm run install-and-restart-kwin-x11
-```
-
-This commands will automatically build the script, package it, install it and
-restart the KWin, so that I can see the changes. No need to worry about the
-steps.
+This will generate the documentation in the build directory.
 
 ## ❓ FAQ
 
@@ -123,10 +95,11 @@ What the use of being a developer if you don't know what to fix or implement?
 
 ### What skills do I need to contribute as a developer?
 
-Bismuth is written in TypeScript, so you'll have to know some. To learn it,
-check out the [Handbook](https://www.typescriptlang.org/docs/handbook/). If you
-know JavaScript and have an experience in some strongly typed language, it will
-be easy, and even if it not, you're still doing a great job - you can do it!
+Bismuth is written in TypeScript and C++, so you'll have to know some. To learn
+TypeScript, check out the
+[Handbook](https://www.typescriptlang.org/docs/handbook/). If you know
+JavaScript and have an experience in some strongly typed language, it will be
+easy, and even if it not, you're still doing a great job - you can do it!
 
 You'll also need to know something about KWin scripting and Qt JavaScript
 Environment. For KWin scripting there is [a tutorial on the KDE developer

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Mikhail Zolotukhin <mail@gikari.com>
+# SPDX-License-Identifier: MIT
+
+all: build
+
+clean:
+	scripts/clean.sh
+
+build:
+	scripts/build.sh
+
+sysdep-install:
+	scripts/sysdep-install.sh
+
+install: build
+	scripts/install.sh
+
+uninstall:
+	scripts/uninstall.sh
+
+restart-kwin-x11:
+	kwin_x11 --replace & disown
+
+restart-plasma:
+	plasmashell --replace & disown
+
+docs:
+	npx typedoc --out build/docs
+
+test:
+	scripts/test.sh
+
+setup-dev-env: sysdep-install
+	pre-commit install
+	npm install # Install development dependencies
+
+.PHONY: clean build sysdep-install install uninstall restart-kwin-x11 restart-plasma docs test setup-dev-env

--- a/package.json
+++ b/package.json
@@ -20,24 +20,6 @@
     "typedoc-plugin-rename-defaults": "0.4.0",
     "typescript": "4.5.2"
   },
-  "scripts": {
-    "clean": "scripts/clean.sh",
-    "build": "scripts/build.sh",
-    "sysdep-install": "scripts/sysdep-install.sh",
-    "prebi-install": "npm run build",
-    "bi-install": "scripts/install.sh",
-    "bi-uninstall": "scripts/uninstall.sh",
-    "restart-kwin-x11": "kwin_x11 --replace & disown",
-    "restart-plasma": "plasmashell --replace & disown",
-    "install-and-restart-kwin-x11": "npm run bi-install",
-    "postinstall-and-restart-kwin-x11": "npm run restart-kwin-x11",
-    "install-and-restart-plasma": "npm run bi-install",
-    "postinstall-and-restart-plasma": "npm run restart-plasma",
-    "install-and-restart": "npm run bi-install",
-    "postinstall-and-restart": "npm run restart-kwin-x11 && npm run restart-plasma",
-    "docs": "npx typedoc --out build/docs",
-    "test": "scripts/test.sh"
-  },
   "license": "MIT",
   "prettier": {}
 }


### PR DESCRIPTION
This makes it possible to name targets whatever we want and makes us
less dependent on the NPM (i.e. a preparation for NPM removal).