### PR TITLE
fix: move old shortcuts to the new component correctly

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,6 +23,7 @@ ecm_qt_declare_logging_category(
 
 add_subdirectory(plasma-api)
 add_subdirectory(engine)
+add_subdirectory(kconf_update)
 
 target_sources(bismuth_core PRIVATE qml-plugin.cpp ts-proxy.cpp controller.cpp
                                     qmldir ${BISMUTH_LOG})

--- a/src/core/kconf_update/CMakeLists.txt
+++ b/src/core/kconf_update/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@gikari.com>
+# SPDX-License-Identifier: MIT
+
+target_sources(bismuth_core PRIVATE legacy_shortcuts.cpp)

--- a/src/core/kconf_update/legacy_shortcuts.cpp
+++ b/src/core/kconf_update/legacy_shortcuts.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@gikari.com>
+// SPDX-License-Identifier: MIT
+
+#include "legacy_shortcuts.hpp"
+
+#include <QAction>
+#include <QKeySequence>
+
+#include <KConfigGroup>
+#include <KGlobalAccel>
+#include <KSharedConfig>
+#include <qdebug.h>
+
+namespace Bismuth
+{
+
+void KConfUpdate::migrate()
+{
+    moveOldKWinShortcutsToNewBismuthComponent();
+}
+
+void KConfUpdate::moveOldKWinShortcutsToNewBismuthComponent()
+{
+    auto globAccel = KGlobalAccel::self();
+
+    auto moveShortcut = [&](const char *oldEntryName, const char *newEntryName) {
+        auto oldKeysequence = globAccel->globalShortcut(QStringLiteral("kwin"), oldEntryName);
+
+        // Remove the old shortcuts
+        auto action = QAction();
+        action.setObjectName(oldEntryName);
+        action.setProperty("componentName", QStringLiteral("kwin"));
+        globAccel->setShortcut(&action, {});
+        globAccel->removeAllShortcuts(&action);
+
+        auto newAction = QAction();
+        action.setObjectName(newEntryName);
+        action.setProperty("componentName", QStringLiteral("bismuth"));
+        globAccel->setShortcut(&action, oldKeysequence, KGlobalAccel::NoAutoloading);
+    };
+
+    auto shortcutsrc = KSharedConfig::openConfig("kglobalshortcutsrc");
+    auto versionGroup = shortcutsrc->group("$Version");
+
+    auto updInfo = versionGroup.readEntry("update_info", QStringList());
+    auto old = updInfo.contains("bismuth_shortcuts_category.upd:bismuth-shortcuts-category");
+
+    auto shouldNotUpdate = updInfo.contains("bismuth_shortcuts_from_kwin.upd:bismuth-shortcuts-from-kwin");
+
+    if (shouldNotUpdate) {
+        return;
+    }
+
+    updInfo.append(QStringLiteral("bismuth_shortcuts_from_kwin.upd:bismuth-shortcuts-from-kwin"));
+
+    moveShortcut("bismuth_decrease_master_size", "decrease_master_size");
+    moveShortcut("bismuth_decrease_master_win_count", "decrease_master_win_count");
+    moveShortcut("bismuth_decrease_window_height", "decrease_window_height");
+    moveShortcut("bismuth_decrease_window_width", "decrease_window_width");
+    moveShortcut("bismuth_focus_bottom_window", "focus_bottom_window");
+    moveShortcut("bismuth_focus_left_window", "focus_left_window");
+    moveShortcut("bismuth_focus_next_window", "focus_next_window");
+    moveShortcut("bismuth_focus_prev_window", "focus_prev_window");
+    moveShortcut("bismuth_focus_right_window", "focus_right_window");
+    moveShortcut("bismuth_focus_upper_window", "focus_upper_window");
+    moveShortcut("bismuth_increase_master_size", "increase_master_size");
+    moveShortcut("bismuth_increase_master_win_count", "increase_master_win_count");
+    moveShortcut("bismuth_increase_window_height", "increase_window_height");
+    moveShortcut("bismuth_increase_window_width", "increase_window_width");
+    moveShortcut("bismuth_move_window_to_bottom_pos", "move_window_to_bottom_pos");
+    moveShortcut("bismuth_move_window_to_left_pos", "move_window_to_left_pos");
+    moveShortcut("bismuth_move_window_to_next_pos", "move_window_to_next_pos");
+    moveShortcut("bismuth_move_window_to_prev_pos", "move_window_to_prev_pos");
+    moveShortcut("bismuth_move_window_to_right_pos", "move_window_to_right_pos");
+    moveShortcut("bismuth_move_window_to_upper_pos", "move_window_to_upper_pos");
+    moveShortcut("bismuth_next_layout", "next_layout");
+    moveShortcut("bismuth_prev_layout", "prev_layout");
+    moveShortcut("bismuth_push_window_to_master", "push_window_to_master");
+    moveShortcut("bismuth_rotate", "rotate");
+    moveShortcut("bismuth_rotate_part", "rotate_part");
+    moveShortcut("bismuth_rotate_reverse", "rotate_reverse");
+    moveShortcut("bismuth_toggle_float_layout", "toggle_float_layout");
+    moveShortcut("bismuth_toggle_monocle_layout", "toggle_monocle_layout");
+    moveShortcut("bismuth_toggle_quarter_layout", "toggle_quarter_layout");
+    moveShortcut("bismuth_toggle_spiral_layout", "toggle_spiral_layout");
+    moveShortcut("bismuth_toggle_spread_layout", "toggle_spread_layout");
+    moveShortcut("bismuth_toggle_stair_layout", "toggle_stair_layout");
+    moveShortcut("bismuth_toggle_three_column_layout", "toggle_three_column_layout");
+    moveShortcut("bismuth_toggle_tile_layout", "toggle_tile_layout");
+    moveShortcut("bismuth_toggle_window_floating", "toggle_window_floating");
+
+    versionGroup.writeEntry("update_info", updInfo);
+}
+}

--- a/src/core/kconf_update/legacy_shortcuts.hpp
+++ b/src/core/kconf_update/legacy_shortcuts.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2022 Mikhail Zolotukhin <mail@gikari.com>
+// SPDX-License-Identifier: MIT
+
+namespace Bismuth
+{
+
+struct KConfUpdate {
+    static void migrate();
+
+private:
+    static void moveOldKWinShortcutsToNewBismuthComponent();
+};
+
+}

--- a/src/core/qml-plugin.cpp
+++ b/src/core/qml-plugin.cpp
@@ -14,6 +14,7 @@
 #include "config.hpp"
 #include "controller.hpp"
 #include "engine/engine.hpp"
+#include "kconf_update/legacy_shortcuts.hpp"
 #include "logger.hpp"
 #include "plasma-api/api.hpp"
 #include "ts-proxy.hpp"
@@ -34,9 +35,8 @@ Core::Core(QQuickItem *parent)
     , m_config()
     , m_plasmaApi()
 {
-    // Force check for the config changes
-    auto kcfg = KSharedConfig::openConfig("kglobalshortcutsrc");
-    kcfg->checkUpdate(QStringLiteral("bismuth-shortcuts-category"), QStringLiteral("bismuth_shortcuts_category.upd"));
+    // Do the necessary migrations, that are not possible from kconf_update
+    Bismuth::KConfUpdate::migrate();
 }
 
 void Core::init()


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

kconf_update script wasn't working, so this new implementation is using
the KGloablAccel directly and before setting the new shortcuts.

This implementation should fix the user's issues for good.

## Test Plan

1. Make that, you have your legacy KWin shortcuts regirstered
1. Reload Script.
2. Old shortcuts should disappear and new ones should be listed.

## Related Issues

Closes #336
