### PR TITLE
fix: ignore spaces in comma separated lists configs

### DIFF
--- a/src/core/ts-proxy.cpp
+++ b/src/core/ts-proxy.cpp
@@ -93,7 +93,7 @@ QJSValue TSProxy::jsConfig()
             if (asNumbers) {
                 arrayProperty.setProperty(i, value.toInt());
             } else {
-                arrayProperty.setProperty(i, value);
+                arrayProperty.setProperty(i, value.trimmed());
             }
         }
     };


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

This should not put the spaces in the comma separated lists of various configs.

## Related Issues

Closes #329
