### PR TITLE
fix(shortcuts_migration): don't override the existing shortcuts

### DIFF
--- a/src/core/kconf_update/legacy_shortcuts.cpp
+++ b/src/core/kconf_update/legacy_shortcuts.cpp
@@ -9,7 +9,6 @@
 #include <KConfigGroup>
 #include <KGlobalAccel>
 #include <KSharedConfig>
-#include <qdebug.h>
 
 namespace Bismuth
 {
@@ -30,13 +29,22 @@ void KConfUpdate::moveOldKWinShortcutsToNewBismuthComponent()
         auto action = QAction();
         action.setObjectName(oldEntryName);
         action.setProperty("componentName", QStringLiteral("kwin"));
+
         globAccel->setShortcut(&action, {});
         globAccel->removeAllShortcuts(&action);
 
         auto newAction = QAction();
         action.setObjectName(newEntryName);
         action.setProperty("componentName", QStringLiteral("bismuth"));
-        globAccel->setShortcut(&action, oldKeysequence, KGlobalAccel::NoAutoloading);
+
+        auto existingKeysequence = globAccel->globalShortcut(QStringLiteral("bismuth"), newEntryName);
+
+        // Only override the shortcut if it's empty
+        // For some reason KGlobalAccel leaves the empty entries sometimes
+        // Therefore we cannot rely on Autoloading
+        if (existingKeysequence.empty()) {
+            globAccel->setShortcut(&action, oldKeysequence, KGlobalAccel::NoAutoloading);
+        }
     };
 
     auto shortcutsrc = KSharedConfig::openConfig("kglobalshortcutsrc");


### PR DESCRIPTION
## Summary

This fixes the issue, when the existing shortcuts are overridden.

## Test Plan

### Scenario One 

Make sure that the `~/.config/kglobalshortcutsrc` DOES NOT have the `bismuth_shortcuts_from_kwin.upd:bismuth-shortcuts-from-kwin` element in `[$Version] update_info` section.

Bismuth old shortcuts exist. New shortcuts are undefined.

1. Reload Script.
2. Old shortcuts are deleted. New are created, and they are identical to the old ones.

### Scenario Two

Bismuth old shortcuts exist. New shortcuts exist.

1. Reload Script.
2. Old shortcuts are deleted. Only the shortcuts that were empty are overridden.

## Related Issues

Closes #343
