### PR TITLE
Add new i3-like dynamic layout

### DIFF
--- a/src/config/bismuth_config.kcfg
+++ b/src/config/bismuth_config.kcfg
@@ -48,6 +48,11 @@
       <default>false</default>
     </entry>
 
+    <entry name="enableDynamicLayout" type="Bool">
+      <label>Enable/disable Tile layout</label>
+      <default>false</default>
+    </entry>
+
     <entry name="ignoreActivity" type="String">
       <label>Do not apply tiling on some activities(comma-separated list of activity names)</label>
       <default></default>

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -178,6 +178,12 @@ void Controller::registerShortcuts()
     addShortcut("rotate_part", "Rotate Sublayout Clockwise", "Meta+Shift+R", [=]() {
         qDebug(Bi) << "Rotate Sublayout Clockwise Triggered!";
     });
+    addShortcut("split_part_horizontally", "Split Part Horizontally", "", [=]() {
+        qDebug(Bi) << "Split Part Horizontally Triggered!";
+    });
+    addShortcut("split_part_vertically", "Split Part Vertically", "", [=]() {
+        qDebug(Bi) << "Split Part Vertically Triggered!";
+    });
 }
 
 void Controller::loadExistingWindows()

--- a/src/core/ts-proxy.cpp
+++ b/src/core/ts-proxy.cpp
@@ -51,6 +51,7 @@ QJSValue TSProxy::jsConfig()
     addLayout("enableQuarterLayout", "QuarterLayout");
     addLayout("enableFloatingLayout", "FloatingLayout");
     addLayout("enableCascadeLayout", "CascadeLayout");
+    addLayout("enableDynamicLayout", "DynamicLayout");
 
     setProp("monocleMaximize", m_config.monocleMaximize());
     setProp("maximizeSoleTile", m_config.maximizeSoleTile());

--- a/src/kcm/package/contents/ui/views/Layouts.qml
+++ b/src/kcm/package/contents/ui/views/Layouts.qml
@@ -57,6 +57,11 @@ Kirigami.Page {
             settingName: "enableFloatingLayout"
         }
 
+        ListElement {
+            name: "Dynamic"
+            settingName: "enableDynamicLayout"
+        }
+
     }
 
     KCM.ScrollView {

--- a/src/kwinscript/controller/action.ts
+++ b/src/kwinscript/controller/action.ts
@@ -599,3 +599,29 @@ export class RotatePart extends ActionImpl implements Action {
     this.engine.showNotification("Rotation Not Applicable");
   }
 }
+
+export class SplitPartHorizontally extends ActionImpl implements Action {
+  constructor(protected engine: Engine, protected log: Log) {
+    super(
+      engine,
+      "split_part_horizontally",
+      "Split Part Horizontally",
+      "",
+      log
+    );
+  }
+
+  public executeWithoutLayoutOverride(): void {
+    this.engine.showNotification("Splitting Not Applicable");
+  }
+}
+
+export class SplitPartVertically extends ActionImpl implements Action {
+  constructor(protected engine: Engine, protected log: Log) {
+    super(engine, "split_part_vertically", "Split Part Vertically", "", log);
+  }
+
+  public executeWithoutLayoutOverride(): void {
+    this.engine.showNotification("Splitting Not Applicable");
+  }
+}

--- a/src/kwinscript/controller/index.ts
+++ b/src/kwinscript/controller/index.ts
@@ -428,6 +428,9 @@ export class ControllerImpl implements Controller {
       new Action.Rotate(this.engine, this.log),
       new Action.RotateReverse(this.engine, this.log),
       new Action.RotatePart(this.engine, this.log),
+
+      new Action.SplitPartHorizontally(this.engine, this.log),
+      new Action.SplitPartVertically(this.engine, this.log),
     ];
 
     for (const action of allPossibleActions) {

--- a/src/kwinscript/engine/index.ts
+++ b/src/kwinscript/engine/index.ts
@@ -399,7 +399,14 @@ export class EngineImpl implements Engine {
       if (this.config.newWindowAsMaster) {
         this.windows.unshift(window);
       } else {
-        this.windows.push(window);
+        const currentWindow = this.currentWindow();
+        if (currentWindow) {
+          this.windows.insertAfter(currentWindow, window);
+
+          const layout = this.currentLayoutOnCurrentSurface();
+          if (layout.handleNewWindow)
+            layout.handleNewWindow(currentWindow, window);
+        } else this.windows.push(window);
       }
     }
   }

--- a/src/kwinscript/engine/layout/dynamic_layout.ts
+++ b/src/kwinscript/engine/layout/dynamic_layout.ts
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2022 Philippe Daouadi <philippe@ud2.org>
+//
+// SPDX-License-Identifier: MIT
+
+import { WindowsLayout } from ".";
+
+import { WindowState, EngineWindow } from "../window";
+
+import {
+  Action,
+  SplitPartHorizontally,
+  SplitPartVertically,
+} from "../../controller/action";
+
+import { Rect, RectDelta } from "../../util/rect";
+import { Config } from "../../config";
+import { Controller } from "../../controller";
+import { Engine } from "..";
+import LayoutUtils from "./layout_utils";
+
+type SplitDirection = "horizontal" | "vertical";
+
+export class DynamicLayoutPart {
+  public gap: number;
+  public direction: SplitDirection;
+  public subParts: Array<DynamicLayoutPart | string>;
+
+  private config: Config;
+
+  constructor(config: Config, direction: SplitDirection = "horizontal") {
+    this.config = config;
+    this.gap = 0;
+    this.direction = direction;
+    this.subParts = [];
+  }
+
+  public split(direction: SplitDirection, currentWindow: EngineWindow): number {
+    const replacePart = (position: number) => {
+      const newPart = new DynamicLayoutPart(this.config, direction);
+      newPart.subParts.push(currentWindow.id);
+      this.subParts[position] = newPart;
+    };
+
+    for (let i = 0; i < this.subParts.length; ++i) {
+      const subPart = this.subParts[i];
+      if (subPart === currentWindow.id) {
+        // If this part contains a single window, replace it instead of nesting
+        // a new split. This operation will be handled by the caller.
+        if (this.subParts.length === 1) return 2;
+
+        replacePart(i);
+        return 1;
+      } else if (subPart instanceof DynamicLayoutPart) {
+        const splitResult = subPart.split(direction, currentWindow);
+        if (splitResult === 1) {
+          return 1;
+        } else if (splitResult === 2) {
+          // The subpart can't handle the split itself, replace it completely.
+          replacePart(i);
+        }
+      }
+    }
+
+    return 0;
+  }
+
+  public prepare(tiles: EngineWindow[], topLevel: boolean = true): void {
+    // Make sure that all windows are referenced. Remove the ones that have
+    // disappeared, and add the potentially new ones at the end. Note that most
+    // window additions should be handled by newWindow().
+    for (let i = 0; i < this.subParts.length; ++i) {
+      const subPart = this.subParts[i];
+      if (subPart instanceof DynamicLayoutPart) {
+        subPart.prepare(tiles, false);
+      } else {
+        if (tiles.length > 0 && subPart === tiles[0].id) {
+          tiles.shift();
+        } else {
+          this.subParts.splice(i, 1);
+          --i;
+        }
+      }
+    }
+    // Remaining windows
+    if (topLevel) {
+      while (tiles.length > 0) {
+        this.subParts.push(tiles[0].id);
+        tiles.shift();
+      }
+    }
+  }
+
+  public handelNewWindow(
+    currentWindow: EngineWindow,
+    newWindow: EngineWindow
+  ): boolean {
+    // The new window was inserted in the WindowStore just after the current
+    // window, so find it so that we can insert it at the same place, and in the
+    // same subpart.
+    for (let i = 0; i < this.subParts.length; ++i) {
+      const subPart = this.subParts[i];
+      if (subPart instanceof DynamicLayoutPart) {
+        if (subPart.handelNewWindow(currentWindow, newWindow)) return true;
+      } else {
+        if (subPart === currentWindow.id) {
+          this.subParts.splice(i + 1, 0, newWindow.id);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public apply(area: Rect, tiles: EngineWindow[]): Rect[] {
+    const partAreas = LayoutUtils.splitAreaWeighted(
+      area,
+      this.subParts.map((_) => 1.0),
+      this.gap,
+      this.direction === "horizontal"
+    );
+    const rects: Array<Rect> = [];
+    this.subParts.forEach((subPart, i) => {
+      if (subPart instanceof DynamicLayoutPart) {
+        const subRects = subPart.apply(partAreas[i], tiles);
+        rects.splice(rects.length, 0, ...subRects);
+      } else {
+        if (subPart !== tiles[0].id) {
+          // FIXME: how are we supposed to log these kind of recoverable errors?
+          console.error(
+            `apply: unexpected window id: ${tiles[0].id}, expected: ${subPart}`
+          );
+        }
+        rects.push(partAreas[i]);
+        tiles.shift();
+      }
+    });
+    return rects;
+  }
+
+  // FIXME: debug stuff, remove
+  public dump(depth: number = 0): void {
+    this.subParts.forEach((subPart) => {
+      if (subPart instanceof DynamicLayoutPart) subPart.dump(depth + 1);
+      else console.log("  ".repeat(depth), subPart);
+    });
+  }
+}
+
+export default class DynamicLayout implements WindowsLayout {
+  public static readonly MIN_MASTER_RATIO = 0.2;
+  public static readonly MAX_MASTER_RATIO = 0.8;
+  public static readonly id = "DynamicLayout";
+  public readonly classID = DynamicLayout.id;
+  public readonly name = "Dynamic Layout";
+  public readonly icon = "bismuth-dynamic";
+
+  private parts: DynamicLayoutPart;
+
+  private config: Config;
+
+  constructor(config: Config) {
+    this.config = config;
+
+    this.parts = new DynamicLayoutPart(this.config);
+
+    this.parts.gap = this.config.tileLayoutGap;
+  }
+
+  public handelNewWindow(
+    currentWindow: EngineWindow,
+    newWindow: EngineWindow
+  ): void {
+    this.parts.handelNewWindow(currentWindow, newWindow);
+  }
+
+  public apply(
+    _controller: Controller,
+    tileables: EngineWindow[],
+    area: Rect
+  ): void {
+    tileables.forEach((tileable) => (tileable.state = WindowState.Tiled));
+    this.parts.dump();
+
+    // Applying the layout must be done in two steps. First we prepare to detect
+    // all windows we might have missed (like when the layout is first used) and
+    // add them to the layout. Then we can apply the layout, once it has been
+    // synchronized with the current windows.
+    this.parts.prepare(tileables.slice());
+    const rects = this.parts.apply(area, tileables.slice());
+    rects.forEach((geometry, i) => {
+      tileables[i].geometry = geometry;
+    });
+  }
+
+  public executeAction(engine: Engine, action: Action): void {
+    this.parts.dump();
+    if (action instanceof SplitPartHorizontally) {
+      const currentWindow = engine.currentWindow();
+      if (currentWindow) this.parts.split("horizontal", currentWindow);
+    } else if (action instanceof SplitPartVertically) {
+      const currentWindow = engine.currentWindow();
+      if (currentWindow) this.parts.split("vertical", currentWindow);
+    } else {
+      action.executeWithoutLayoutOverride();
+    }
+    this.parts.dump();
+  }
+
+  public toString(): string {
+    return `DynamicLayout()`;
+  }
+}

--- a/src/kwinscript/engine/layout/index.ts
+++ b/src/kwinscript/engine/layout/index.ts
@@ -37,6 +37,8 @@ export abstract class WindowsLayout {
    */
   readonly capacity?: number;
 
+  handleNewWindow?(currentWindow: EngineWindow, newWindow: EngineWindow): void;
+
   adjust?(
     area: Rect,
     tiles: EngineWindow[],

--- a/src/kwinscript/engine/layout_store.ts
+++ b/src/kwinscript/engine/layout_store.ts
@@ -14,6 +14,7 @@ import { Config } from "../config";
 import MonocleLayout from "./layout/monocle_layout";
 import TileLayout from "./layout/tile_layout";
 import CascadeLayout from "./layout/cascade_layout";
+import DynamicLayout from "./layout/dynamic_layout";
 import QuarterLayout from "./layout/quarter_layout";
 import SpiralLayout from "./layout/spiral_layout";
 import SpreadLayout from "./layout/spread_layout";
@@ -96,6 +97,8 @@ export class LayoutStoreEntry {
       return new ThreeColumnLayout(this.config);
     } else if (id == TileLayout.id) {
       return new TileLayout(this.config);
+    } else if (id == DynamicLayout.id) {
+      return new DynamicLayout(this.config);
     } else {
       return new FloatingLayout();
     }

--- a/src/kwinscript/engine/window_store.ts
+++ b/src/kwinscript/engine/window_store.ts
@@ -38,6 +38,11 @@ export interface WindowStore {
   allWindowsOn(surf: DriverSurface): EngineWindow[];
 
   /**
+   * Insert a window after another one
+   */
+  insertAfter(after: EngineWindow, toInsert: EngineWindow): void;
+
+  /**
    * Inserts the window at the beginning
    */
   unshift(window: EngineWindow): void;
@@ -123,6 +128,10 @@ export class WindowStoreImpl implements WindowStore {
 
   public indexOf(window: EngineWindow): number {
     return this.list.indexOf(window);
+  }
+
+  public insertAfter(after: EngineWindow, toInsert: EngineWindow) {
+    this.list.splice(this.list.indexOf(after) + 1, 0, toInsert);
   }
 
   public push(window: EngineWindow): void {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

This PR implements a new layout similar to i3's (and sway's) behavior. If you don't know i3, the main difference with bismuth is that i3 doesn't have predefined layouts. You compose your layout as you go by splitting your screen in vertical and horizontal containers.

This is not a full implementation, more like an early draft to get your opinion. I tried implementing the change in the least intrusive way, but I had to make a few changes in the generic Engine code too.

To implement this layout, I had to keep track of windows in the layout itself. So there are two different states with the list of the windows: the WindowsStore, and the layout's list. This introduce some complexity, and potentially bugs if those states desync. I'm wondering if this really is the right approach, I'm starting to think we should aim for a bigger change in the core of bismuth to implement nested layouts (#93) to have more robust code and more features (the nesting itself). Feedback is welcome :)

## Things left to implement

- Moving windows. Moving a window is not a simple swap, you can move window in and out of containers and they should not swap positions.
- Nesting different kind of layouts (as talked before). In i3, you can have an horizontal container, and in the left side have a tabbed container.
- Resizing windows and containers. I think this is related to the adjust method, I didn't look into the matter at all yet.

## Breaking Changes

The first commit changes the behavior of bismuth regarding new windows. Instead of adding them at the end of the list, new windows are now added just next to the current one.

## UI Changes

![image](https://user-images.githubusercontent.com/1370530/166108388-bec77f31-366b-4067-a6c4-4fc774f608f7.png)

## Test Plan

Not planned yet

## Related Issues

Closes #182
