### PR TITLE
docs: official fedora repository installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ contact the package maintainer first.
 
 #### Fedora
 
-- [Capucho Copr](https://copr.fedorainfracloud.org/coprs/capucho/bismuth)
+- [Official Repo](https://src.fedoraproject.org/rpms/bismuth):
+
+  ```bash
+  sudo dnf install bismuth
+  ```
 
 #### OpenSUSE Tumbleweed
 


### PR DESCRIPTION
Hi,

I started the process of package review in Fedora for bismuth so we can install directly via "dnf " without adding extra repository.  Once package review is complete I would like to see merge this request merged and replace current readme with official way of installation for Fedora. 

Latest version copr repo : https://copr.fedorainfracloud.org/coprs/g/kdesig/bismuth/
(It will be not update once package pushed to fedora, it is here for testing)

Fedora package review link  : https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2080701

Thank you. 