### PR TITLE
fix windows unable to move between screens

### DIFF
--- a/src/kwinscript/controller/index.ts
+++ b/src/kwinscript/controller/index.ts
@@ -78,6 +78,12 @@ export interface Controller {
   onWindowResizeStart(window: EngineWindow): void;
 
   /**
+   * React to window changing screens
+   * @param window the window whose screen has changed
+   */
+  onWindowScreenChanged(window: EngineWindow): void;
+
+  /**
    * React to window resize operation end. The window
    * resize operation ends, when the users drops
    * the window.
@@ -336,7 +342,11 @@ export class ControllerImpl implements Controller {
 
   public onWindowGeometryChanged(window: EngineWindow): void {
     this.log.log(["onWindowGeometryChanged", { window }]);
-    this.engine.enforceSize(window);
+  }
+
+  public onWindowScreenChanged(_window: EngineWindow): void {
+    //TODO only arrange the surface the window came from and went to
+    this.engine.arrange();
   }
 
   // NOTE: accepts `null` to simplify caller. This event is a catch-all hack

--- a/src/kwinscript/driver/index.ts
+++ b/src/kwinscript/driver/index.ts
@@ -362,9 +362,9 @@ export class DriverImpl implements Driver {
       }
     });
 
-    this.connect(client.screenChanged, () =>
-      this.controller.onWindowChanged(window, `screen=${client.screen}`)
-    );
+    this.connect(client.screenChanged, () => {
+      this.controller.onWindowScreenChanged(window);
+    });
 
     this.connect(client.activitiesChanged, () =>
       this.controller.onWindowChanged(


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Currently on recent (?) versions of kwin we don't rearrange the tiles correctly when kwin moves windows between monitors instantaneously (versus dragging by mouse) and instead we arrange the moved window back to its original location. This PR fixes that.

~~I don't think this is the right way to fix it, but since the fix is reported to work and the bug is reported to be severe, I think we should do this for now. I'm currently investigating what changed about the events we receive from kwin. I think there are some other event-related issues too like for example when moving windows between activities or desktops, so I think a wider solution is needed here like maybe finding some missing events.~~

## Test Plan

* try moving a window between screens using a kwin keyboard shortcut
* without this PR, the previous step fails

## Related Issues

Closes #370, closes #374
