### PR TITLE
fix windows not tiling after changing desktops or activities

### DIFF
--- a/src/kwinscript/driver/index.ts
+++ b/src/kwinscript/driver/index.ts
@@ -222,6 +222,14 @@ export class DriverImpl implements Driver {
         "unminimized"
       );
 
+    this.connect(this.kwinApi.workspace.currentActivityChanged, () =>
+      this.controller.onCurrentSurfaceChanged()
+    );
+
+    this.connect(this.kwinApi.workspace.currentDesktopChanged, () =>
+      this.controller.onCurrentSurfaceChanged()
+    );
+
     this.connect(this.kwinApi.workspace.clientAdded, onClientAdded);
     this.connect(this.kwinApi.workspace.clientRemoved, onClientRemoved);
     this.connect(this.kwinApi.workspace.clientMaximizeSet, onClientMaximizeSet);


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Currently the signals we're getting from kwin aren't causing us to retile windows when they're moved between desktops or activities. This PR connects the signals so we trigger a retile when either the desktop or activity is changed.

## Test Plan

* move a window from the current desktop/activity to a different one
* switch to that desktop/activity
* without this fix, the desktop/activity is not tiled to reflect the moved window

## Related Issues

Closes #363
