### PR TITLE
fix: don't crash on color config change

### DIFF
--- a/src/kdecoration/decoration.cpp
+++ b/src/kdecoration/decoration.cpp
@@ -87,7 +87,7 @@ void Decoration::connectEvents()
     });
     connect(settingsPtr, &KDecoration2::DecorationSettings::borderSizeChanged, this, &Decoration::setBorderSizes);
 
-    connect(m_kdeglobalsWatcher.data(), &KConfigWatcher::configChanged, [this](const KConfigGroup &group, const QByteArrayList &names) {
+    connect(m_kdeglobalsWatcher.data(), &KConfigWatcher::configChanged, this, [this](const KConfigGroup &group, const QByteArrayList &names) {
         if (group.name() == QStringLiteral("General")) {
             if (names.contains(QByteArrayLiteral("ColorScheme")) || names.contains(QByteArrayLiteral("AccentColor"))) {
                 updateColors();


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Added `this`, so that the lambda does not outlive the class.

## Related Issues

Closes #379 
