### PR TITLE
Fix borders not resotring when exit monocle layout

### DIFF
--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -246,7 +246,7 @@ export class DriverWindowImpl implements DriverWindow {
     if (noBorder !== undefined) {
       if (!this.noBorderManaged && noBorder) {
         /* Backup border state when transitioning from unmanaged to managed */
-        this.noBorderOriginal = this.client.noBorder;
+        this.noBorderOriginal = true;
       } else if (this.noBorderManaged && !this.client.noBorder) {
         /* If border is enabled while in managed mode, remember it.
          * Note that there's no way to know if border is re-disabled in managed mode. */
@@ -258,7 +258,7 @@ export class DriverWindowImpl implements DriverWindow {
         this.client.noBorder = true;
       } else if (this.noBorderManaged) {
         /* Exiting managed mode: restore original value. */
-        this.client.noBorder = this.noBorderOriginal;
+        this.client.noBorder = false;
       }
 
       /* update mode */


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Fixes borders not restoring after exiting monocle layout

## Breaking Changes

Breaks restoration of the original borders state (not sure why this is needed)

## Related Issues

Closes #349
