### PR TITLE
feat: smartgaps: Hide gaps if showing a single window

### DIFF
--- a/src/config/bismuth_config.kcfg
+++ b/src/config/bismuth_config.kcfg
@@ -163,6 +163,11 @@
       <default>0</default>
     </entry>
 
+    <entry name="smartGaps" type="Bool">
+      <label>Hide gaps if showing a single window</label>
+      <default>false</default>
+    </entry>
+
     <entry name="limitTileWidth" type="Bool">
       <label>Limit the width of tiles</label>
       <default>false</default>

--- a/src/core/engine/engine.cpp
+++ b/src/core/engine/engine.cpp
@@ -230,11 +230,11 @@ Surface Engine::activeSurface() const
 void Engine::arrangeWindowsOnSurface(const Surface &surface)
 {
     auto &layout = m_activeLayouts.layoutOnSurface(surface);
-    auto tilingArea = layout.tilingArea(workingArea(surface));
 
     auto visibleWindows = m_windows.visibleWindowsOn(surface);
     auto windowsThatCanBeTiled = visibleWindows; // TODO: Filter windows
 
+    auto tilingArea = layout.tilingArea(workingArea(surface), windowsThatCanBeTiled);
     layout.apply(tilingArea, windowsThatCanBeTiled);
 }
 

--- a/src/core/engine/layout/layout.cpp
+++ b/src/core/engine/layout/layout.cpp
@@ -10,8 +10,12 @@ Layout::Layout(const Bismuth::Config &config)
 {
 }
 
-QRect Layout::tilingArea(QRect workingArea) const
+QRect Layout::tilingArea(QRect workingArea, std::vector<Window> &windows) const
 {
+    if (windows.size() == 1 && m_config.smartGaps()) {
+        return workingArea;
+    }
+
     auto marginLeft = m_config.screenGapLeft();
     auto marginTop = m_config.screenGapTop();
     auto marginRight = m_config.screenGapRight();

--- a/src/core/engine/layout/layout.hpp
+++ b/src/core/engine/layout/layout.hpp
@@ -24,7 +24,7 @@ struct Layout {
     /**
      * Get the area on which tiled windows could be placed given the general @p workingArea
      */
-    virtual QRect tilingArea(QRect workingArea) const;
+    virtual QRect tilingArea(QRect workingArea, std::vector<Window> &windows) const;
 
 protected:
     const Bismuth::Config &m_config;

--- a/src/core/ts-proxy.cpp
+++ b/src/core/ts-proxy.cpp
@@ -75,6 +75,7 @@ QJSValue TSProxy::jsConfig()
     setProp("screenGapRight", m_config.screenGapRight());
     setProp("screenGapTop", m_config.screenGapTop());
     setProp("tileLayoutGap", m_config.tileLayoutGap());
+    setProp("smartGaps", m_config.smartGaps());
 
     setProp("newWindowAsMaster", m_config.newWindowAsMaster());
     setProp("layoutPerActivity", m_config.layoutPerActivity());

--- a/src/kcm/package/contents/ui/Appearance.qml
+++ b/src/kcm/package/contents/ui/Appearance.qml
@@ -41,6 +41,11 @@ Kirigami.FormLayout {
         Kirigami.FormData.label: "Inner Gaps"
     }
 
+    BIC.ConfigCheckBox {
+        text: i18n("Hide gaps if showing a single window")
+        settingName: "smartGaps"
+    }
+
     BIC.PixelsConfigSpinBox {
         Kirigami.FormData.label: i18n("All:")
         settingName: "tileLayoutGap"

--- a/src/kwinscript/config.ts
+++ b/src/kwinscript/config.ts
@@ -26,6 +26,7 @@ export interface Config {
   screenGapRight: number;
   screenGapTop: number;
   tileLayoutGap: number;
+  smartGaps: boolean;
   //#endregion
 
   //#region Behavior


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary
Adds a toggle that will hide gaps if only a single window is visible. The feature is disabled by default.

Implementation added to both the cpp and ts engines.

## Breaking Changes

No

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| ![before](https://user-images.githubusercontent.com/41774/183078023-4223c9f9-86d7-4225-a68c-880062cdc289.png) | ![after](https://user-images.githubusercontent.com/41774/183078052-bcbece63-8e87-48ee-8636-528710972c74.png) |

## Test Plan

1. Make sure gaps are enabled, enable the smart gaps toggle, apply.
2. Put a single window in the workspace, observe that there are no gaps.
3. Open a second window, observe that there are gaps.

## Related Issues

Closes #404
