### PR TITLE
Update Solus install instructions to match other distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ contact the package maintainer first.
   ```bash
   sudo dnf install bismuth
   ```
+  
+#### Solus
+
+- [Official Repo](https://dev.getsol.us/source/bismuth)
+
+  ```bash
+  sudo eopkg install bismuth
+  ```
 
 #### OpenSUSE Tumbleweed
 
@@ -100,10 +108,6 @@ contact the package maintainer first.
 #### Gentoo
 
 - [VipreML Overlay](https://github.com/viperML/viperML-overlay/)
-
-#### Solus
-
-- [Solus](https://dev.getsol.us/source/bismuth)
 
 #### From Source
 


### PR DESCRIPTION
## Summary

Sorry for another minor docs PR, but it bugged me that the install details for Solus were different to the other distros with bismuth in official repositories.