### PR TITLE
Update Conky capitalization on ignore list

### DIFF
--- a/src/config/bismuth_config.kcfg
+++ b/src/config/bismuth_config.kcfg
@@ -55,7 +55,7 @@
 
     <entry name="ignoreClass" type="String">
       <label>Ignore windows with certain classes(comma-separated list)</label>
-      <default>yakuake,spectacle,Conky,zoom</default>
+      <default>yakuake,spectacle,conky,zoom</default>
     </entry>
 
     <entry name="ignoreRole" type="String">


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Fixes Conky class name capitalization such that it gets ignored by default. 

## Breaking Changes
It may be possible that some distros have Conky class name capitalized, hence this change might affect those. To the best of my knowledge, the Conky class name is not capitalized.

## UI Changes
None

## Test Plan
Tested on MX-21.2.1 “Wildflower” release Plasma flavor. 

1. Use Conky with bismuth
2. Conky is getting tiled
3. Update `src\config\bismuth_config.kcfg` elemet `ignoreClass`,  `Conky` -> `conky`
4. Conky is no longer managed

## Related Issues

https://github.com/Bismuth-Forge/bismuth/pull/99/commits/86129e5281ac5edac62acbd82e4c3b6f6a2ed470

