### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ contact the package maintainer first.
 
 #### OpenSUSE Tumbleweed
 
-- [home:rxmd OBS Repository](https://build.opensuse.org/package/show/home:rxmd/kwin-script-tiling-bismuth)
+- [home:rxmd OBS Repository](https://build.opensuse.org/package/show/home:rxmd/bismuth)
 
 #### Gentoo
 


### PR DESCRIPTION
## Summary

The OpenSUSE package got renamed (`bismuth` instead of `kwin-script-tiling-bismuth`), here's an update to the documentation to reflect this.