### PR TITLE
fix: Add pinentry-qt to the default ignore list

### DIFF
--- a/src/config/bismuth_config.kcfg
+++ b/src/config/bismuth_config.kcfg
@@ -55,7 +55,7 @@
 
     <entry name="ignoreClass" type="String">
       <label>Ignore windows with certain classes(comma-separated list)</label>
-      <default>yakuake,spectacle,Conky,zoom</default>
+      <default>yakuake,spectacle,Conky,zoom,pinentry-qt</default>
     </entry>
 
     <entry name="ignoreRole" type="String">


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

> Note: I haven't read CONTRIBUTING.md yet, so I might force push the branch if I notice something is off.

## Summary
The pinentry-qt password prompt is inherently a popup and is not expected to be tiled or to change the current tiling arrangement.

## Breaking Changes

None, changing default settings

## UI Changes
None, so no screenshot

## Test Plan
None, it's a default config

## Related Issues

It is _related_ to the question in #394, but does _not_ close it, I am actually also interested in the answer.
