### PR TITLE
Update README.md to include new Tumbleweed repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ contact the package maintainer first.
 
 #### OpenSUSE Tumbleweed
 
-- [home:rxmd OBS Repository](https://build.opensuse.org/package/show/home:rxmd/kwin-script-tiling-bismuth)
+- [KDE Extra Repository](https://build.opensuse.org/package/show/KDE:Extra/bismuth)
 
 #### Gentoo
 


### PR DESCRIPTION
OpenSUSE Tumbleweed now has Bismuth in its KDE:Extra staging repository.

## Summary

Update to README.md to reflect the new repository for OpenSUSE Tumbleweed.
