### PR TITLE
fix: ignore dialog

### DIFF
--- a/src/kwinscript/controller/index.ts
+++ b/src/kwinscript/controller/index.ts
@@ -342,6 +342,8 @@ export class ControllerImpl implements Controller {
 
   public onWindowGeometryChanged(window: EngineWindow): void {
     this.log.log(["onWindowGeometryChanged", { window }]);
+
+    this.engine.arrange();
   }
 
   public onWindowScreenChanged(_window: EngineWindow): void {

--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -111,6 +111,7 @@ export class DriverWindowImpl implements DriverWindow {
     const windowRole = String(this.client.windowRole);
     return (
       this.client.specialWindow ||
+      this.client.dialog ||
       resourceClass === "plasmashell" ||
       resourceClass === "ksmserver" ||
       resourceClass === "org.kde.plasmashell" ||


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

I use Intellij IDEA to do my work, and found that Dialog windows such as right-click menus and floating prompts will be tiled in the stack by mistake. I think other software should have similar problems, so I think Dialog windows should be ignored, which is also default behavior for other Tiling Window Managers


## Breaking Changes

None

## UI Changes

None

## Test Plan

1. Open IntelliJ IDEA
2. Right click menu or trigger a floating alert
3. Dialogs are correctly drawn next to the mouse pointer instead of being tiled on the stack

## Related Issues

Closes #X
