### PR TITLE
fix: Use optional chaining to fix error when windowId is undefined in Wayland

### DIFF
--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -292,7 +292,7 @@ export class DriverWindowImpl implements DriverWindow {
 
   public toString(): string {
     // Using a shorthand name to keep debug message tidy
-    return `KWin(${this.client.windowId.toString(16)}.${
+    return `KWin(${this.client.windowId?.toString(16)}.${
       this.client.resourceClass
     })`;
   }


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary
On KWin Wayland (5.27.6), I noticed that bismuth is throwing the ff. error when tiling Firefox causing tiling to break so I investigated and was able to pinpoint the error. It turns out windowId is undefined for some apps so I changed it to optional chaining which fixed the problems I've been having with tiling.
```
org.kde.bismuth: arrangeScreen/finished,[object Object]
org.kde.bismuth: Oops! TypeError: Cannot read property 'toString' of undefined.
org.kde.bismuth: Client added: KWin::XwaylandWindow(0x556f7f219900)
```

Here's how it worked before this change (the other windows don't resize immediately, eventually they stop tiling altogether):


https://github.com/Bismuth-Forge/bismuth/assets/4564810/2baaaaa9-3902-4bc4-b28c-c1f6514ea2c5


Here's how it worked after this change (the other windows resize immediately):


https://github.com/Bismuth-Forge/bismuth/assets/4564810/7ccfb2f5-3cb6-40f6-bcf7-85a666b84cc8



## Breaking Changes
Should not break anything.

## UI Changes
None

## Test Plan
1. On KDE Plasma Wayland, open Firefox
2. Open three new windows
3. Close two of the three windows that you just opened 
    a. The remaining windows should resize correctly
    b. Previously, these windows don't resize as one of the handlers throws the above error and fails to process the event

## Related Issues
Potentially closes #473 or at least fixes one problem related to wayland.
