### PR TITLE
Update README to include link to bismuth nix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ contact the package maintainer first.
 
 - [VipreML Overlay](https://github.com/viperML/viperML-overlay/)
 
+#### Nix
+
+- [nix packages](https://search.nixos.org/packages?channel=23.11&show=libsForQt5.bismuth&from=0&size=50&sort=relevance&type=packages&query=bismuth)
+
+  ```bash
+  nix-shell -p libsForQt5.bismuth
+  ```
+
 #### From Source
 
 - [See Dev Docs](CONTRIBUTING.md)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

just found `bismuth` on nix store, didn't add it myself

update `README.md` to include nix entry

> https://search.nixos.org/packages?channel=23.11&show=libsForQt5.bismuth&from=0&size=50&sort=relevance&type=packages&query=bismuth

## Breaking Changes

just documentation changes

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| ![image](https://github.com/Bismuth-Forge/bismuth/assets/24394426/34f5a8d4-b064-4f6a-90fe-4105939dd08c) |  ![image](https://github.com/Bismuth-Forge/bismuth/assets/24394426/7c177717-baf3-41ea-abc6-dc881072b4d0) |

## Test Plan

just documentation changes

## Related Issues

no issues afaik
